### PR TITLE
feat: add actions(register, refresh) to cluster selector

### DIFF
--- a/web/src/components/GlobalHeader/index.js
+++ b/web/src/components/GlobalHeader/index.js
@@ -63,8 +63,6 @@ export default class GlobalHeader extends PureComponent {
               width={300}
               dropdownWidth={400}
               selectedCluster={selectedCluster} 
-              clusterList={clusterList}
-              clusterStatus={clusterStatus}
               onChange={(item) => {
                 const rel = this.props
                   .handleSaveGlobalState({

--- a/web/src/pages/Agent/Instance/components/AutoEnroll.jsx
+++ b/web/src/pages/Agent/Instance/components/AutoEnroll.jsx
@@ -32,8 +32,6 @@ export default ({ onEnroll, loading }) => {
           width={"100%"}
           dropdownWidth={400}
           selectedCluster={selectedCluster}
-          clusterList={clusterList}
-          clusterStatus={clusterStatus}
           onChange={(item) => {
             setSelectedCluster(item);
           }}

--- a/web/src/pages/Agent/Instance/components/UnknownAssociate.jsx
+++ b/web/src/pages/Agent/Instance/components/UnknownAssociate.jsx
@@ -32,8 +32,6 @@ export default ({ onBatchEnroll, loading }) => {
           width={"100%"}
           dropdownWidth={400}
           selectedCluster={selectedCluster}
-          clusterList={clusterList}
-          clusterStatus={clusterStatus}
           onChange={(item) => {
             console.log("onChange item:", item);
             setSelectedCluster(item);

--- a/web/src/pages/Alerting/Rule/Form.jsx
+++ b/web/src/pages/Alerting/Rule/Form.jsx
@@ -477,8 +477,6 @@ const RuleForm = (props) => {
                 width={300}
                 dropdownWidth={400}
                 selectedCluster={selectedCluster} 
-                clusterList={props.clusterList}
-                clusterStatus={props.clusterStatus}
                 onChange={(item) => {
                   setSelectedCluster(item);
                 }}

--- a/web/src/pages/DevTool/Console.tsx
+++ b/web/src/pages/DevTool/Console.tsx
@@ -18,10 +18,10 @@ import { TabTitle } from "./console_tab_title";
 import "@/assets/utility.scss";
 import { Resizable } from "re-resizable";
 import { ResizeBar } from "@/components/infini/resize_bar";
-import NewTabMenu from "./NewTabMenu";
 
 import maximizeSvg from "@/assets/window-maximize.svg";
 import restoreSvg from "@/assets/window-restore.svg";
+import ClusterSelect from "@/components/ClusterSelect";
 
 const MaximizeIcon = (props = {}) => {
   return <img height="14px" width="14px" {...props} src={maximizeSvg} />;
@@ -282,19 +282,6 @@ export const ConsoleUI = ({
     [clusterList]
   );
 
-  // const menu = (
-  //   // <Menu onClick={newTabClick}>
-  //   //   {(clusterList||[]).map((cluster:any)=>{
-  //   //     return <Menu.Item key={cluster.id}>{cluster.name}</Menu.Item>
-  //   //   })}
-  //   // </Menu>
-  //   <NewTabMenu data={clusterList}
-  //   onItemClick={newTabClick}
-  //   clusterStatus={clusterStatus}
-  //   size={10}
-  //   width="300px"/>
-  // );
-
   const rootRef = useRef(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const fullscreenClick = () => {
@@ -340,17 +327,15 @@ export const ConsoleUI = ({
       </>
     ),
     append: (
-      <NewTabMenu
-        data={clusterList}
-        onItemClick={newTabClick}
-        clusterStatus={clusterStatus}
-        size={10}
-        width="500px"
+      <ClusterSelect 
+        width={34}
+        dropdownWidth={400}
+        onChange={(item) => newTabClick(item)}
       >
         <div className="tabbar-icon">
           <Icon type="plus" />
         </div>
-      </NewTabMenu>
+      </ClusterSelect>  
     ),
   };
 
@@ -487,7 +472,7 @@ export const ConsoleUI = ({
   );
 };
 
-export default connect(({ global }) => ({
+export default connect(({ global, loading }) => ({
   selectedCluster: global.selectedCluster,
   clusterList: global.clusterList,
   clusterStatus: global.clusterStatus,

--- a/web/src/pages/DevTool/NewTabMenu.jsx
+++ b/web/src/pages/DevTool/NewTabMenu.jsx
@@ -11,24 +11,31 @@ class NewTabMenu extends React.Component {
   };
   constructor(props) {
     super(props);
-    this.state = {
-      data: this.props.data || [],
-    };
   }
 
   componentDidMount() {}
 
 
   render() {
-    const { clusterStatus } = this.props;
+    const { clusterList, clusterStatus, clusterLoading, dispatch } = this.props;
     return (
       <div>
         <ClusterSelect 
           width={34}
           dropdownWidth={400}
-          clusterList={this.state.data}
+          clusterList={clusterList}
           clusterStatus={clusterStatus}
           onChange={(item) => this.handleItemClick(item)}
+          loading={clusterLoading}
+          onRefresh={() => {
+            dispatch({
+              type: "global/fetchClusterList",
+              payload: {
+                size: 200,
+                name: "",
+              },
+            });
+          }}
         >
           {this.props.children}
         </ClusterSelect>  


### PR DESCRIPTION
## What does this PR do
1. add actions(register, refresh) to cluster selector

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Performance tests checked, no obvious performance degradation
- [ ] Necessary documents have been added if this is a new feature