### PR TITLE
feat: add getting cluster collection stats api

### DIFF
--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -1,0 +1,83 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package errors
+
+import (
+	"fmt"
+	"infini.sh/framework/core/errors"
+)
+
+const (
+	ErrTypeRequestParams = "request_params_error"
+	ErrTypeApplication = "application_error"
+	ErrTypeAlreadyExists = "already_exists_error"
+	ErrTypeNotExists = "not_exists_error"
+	ErrTypeIncorrectPassword = "incorrect_password_error"
+	ErrTypeDomainPrefixMismatch = "domain_prefix_mismatch_error"
+	ErrTypeDisabled = "disabled_error"
+	ErrTypeRequestTimeout = "request_timeout_error"
+)
+
+var (
+	ErrPasswordIncorrect = errors.New("incorrect password")
+	ErrNotExistsErr = errors.New("not exists")
+)
+
+type Error struct {
+	typ string
+	msg interface{}
+	field string
+}
+
+func (err Error) Error() string {
+	return fmt.Sprintf("%s:%v: %v", err.typ, err.field, err.msg)
+}
+
+//NewAppError returns an application error
+func NewAppError(msg any) *Error {
+	return New(ErrTypeApplication, "", msg)
+}
+
+//NewParamsError returns a request params error
+func NewParamsError(field string, msg any) *Error {
+	return New(ErrTypeRequestParams, field, msg)
+}
+
+//NewAlreadyExistsError returns an already exists error
+func NewAlreadyExistsError(field string, msg any) *Error {
+	return New(ErrTypeAlreadyExists, field, msg)
+}
+
+//NewNotExistsError returns a not exists error
+func NewNotExistsError(field string, msg any) *Error {
+	return New(ErrTypeNotExists, field, msg)
+}
+
+func New(typ string, field string, msg any) *Error {
+	return &Error{
+		typ,
+		msg,
+		field,
+	}
+}

--- a/modules/elastic/api/index_metrics.go
+++ b/modules/elastic/api/index_metrics.go
@@ -742,7 +742,7 @@ func (h *APIHandler) getIndexMetrics(ctx context.Context, req *http.Request, clu
 			},
 		},
 	}
-	return h.getMetrics(ctx, query, indexMetricItems, bucketSize), nil
+	return h.getMetrics(ctx, query, indexMetricItems, bucketSize)
 
 }
 

--- a/modules/elastic/api/index_overview.go
+++ b/modules/elastic/api/index_overview.go
@@ -531,7 +531,11 @@ func (h *APIHandler) FetchIndexInfo(w http.ResponseWriter,  req *http.Request, p
 			},
 		},
 	}
-	metrics := h.getMetrics(ctx, query, nodeMetricItems, bucketSize)
+	metrics, err := h.getMetrics(ctx, query, nodeMetricItems, bucketSize)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err, http.StatusInternalServerError)
+	}
 	indexMetrics := map[string]util.MapStr{}
 	for key, item := range metrics {
 		for _, line := range item.Lines {
@@ -921,6 +925,8 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 			healthMetric, err := h.GetIndexHealthMetric(ctx, clusterID, indexName, min, max, bucketSize)
 			if err != nil {
 				log.Error(err)
+				h.WriteError(w, err, http.StatusInternalServerError)
+				return
 			}
 			metrics["index_health"] = healthMetric
 	} else {
@@ -987,7 +993,11 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 			}
 			metricItems = append(metricItems, metricItem)
 		}
-		metrics = h.getSingleIndexMetrics(context.Background(), metricItems, query, bucketSize)
+		metrics, err = h.getSingleIndexMetrics(context.Background(), metricItems, query, bucketSize)
+		if err != nil {
+			log.Error(err)
+			h.WriteError(w, err, http.StatusInternalServerError)
+		}
 	}
 
 	resBody["metrics"] = metrics

--- a/modules/elastic/api/index_overview.go
+++ b/modules/elastic/api/index_overview.go
@@ -439,7 +439,12 @@ func (h *APIHandler) FetchIndexInfo(w http.ResponseWriter,  req *http.Request, p
 				},
 				{
 					"term": util.MapStr{
-						"metadata.labels.index_id": newIndexIDs[0],
+						"metadata.labels.cluster_id": firstClusterID,
+					},
+				},
+				{
+					"term": util.MapStr{
+						"metadata.labels.index_name": firstIndexName,
 					},
 				},
 			},

--- a/modules/elastic/api/index_overview.go
+++ b/modules/elastic/api/index_overview.go
@@ -303,7 +303,7 @@ func (h *APIHandler) FetchIndexInfo(w http.ResponseWriter,  req *http.Request, p
 			return
 		}
 		firstClusterID, firstIndexName = parts[0], parts[1]
-		if GetMonitorState(firstClusterID) == Console {
+		if GetMonitorState(firstClusterID) == elastic.ModeAgentless {
 			h.APIHandler.FetchIndexInfo(w, ctx, indexIDs)
 			return
 		}
@@ -580,7 +580,7 @@ func (h *APIHandler) FetchIndexInfo(w http.ResponseWriter,  req *http.Request, p
 
 func (h *APIHandler) GetIndexInfo(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	clusterID := ps.MustGetParameter("id")
-	if GetMonitorState(clusterID) == Console {
+	if GetMonitorState(clusterID) == elastic.ModeAgentless {
 		h.APIHandler.GetIndexInfo(w, req, ps)
 		return
 	}
@@ -701,7 +701,7 @@ func (h *APIHandler) GetIndexInfo(w http.ResponseWriter, req *http.Request, ps h
 
 func (h *APIHandler) GetIndexShards(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	clusterID := ps.MustGetParameter("id")
-	if GetMonitorState(clusterID) == Console {
+	if GetMonitorState(clusterID) == elastic.ModeAgentless {
 		h.APIHandler.GetIndexShards(w, req, ps)
 		return
 	}
@@ -810,7 +810,7 @@ func (h *APIHandler) GetIndexShards(w http.ResponseWriter, req *http.Request, ps
 
 func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	clusterID := ps.MustGetParameter("id")
-	if GetMonitorState(clusterID) == Console {
+	if GetMonitorState(clusterID) == elastic.ModeAgentless {
 		h.APIHandler.GetSingleIndexMetrics(w, req, ps)
 		return
 	}

--- a/modules/elastic/api/init.go
+++ b/modules/elastic/api/init.go
@@ -86,7 +86,7 @@ func init() {
 	api.HandleAPIMethod(api.POST, "/elasticsearch/cluster/info", clusterAPI.RequirePermission(clusterAPI.FetchClusterInfo, enum.PermissionElasticsearchMetricRead))
 
 	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/info", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.GetClusterInfo, enum.PermissionElasticsearchMetricRead)))
-	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/monitor_state", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.getClusterMonitorState, enum.PermissionElasticsearchMetricRead)))
+	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/_collection_stats", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.getClusterMonitorState, enum.PermissionElasticsearchMetricRead)))
 	api.HandleAPIMethod(api.POST, "/elasticsearch/node/_search", clusterAPI.RequirePermission(clusterAPI.SearchNodeMetadata, enum.PermissionElasticsearchNodeRead))
 	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/nodes", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.GetClusterNodes, enum.PermissionElasticsearchMetricRead, enum.PermissionElasticsearchNodeRead)))
 	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/nodes/realtime", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.GetRealtimeClusterNodes, enum.PermissionElasticsearchMetricRead)))

--- a/modules/elastic/api/init.go
+++ b/modules/elastic/api/init.go
@@ -86,6 +86,7 @@ func init() {
 	api.HandleAPIMethod(api.POST, "/elasticsearch/cluster/info", clusterAPI.RequirePermission(clusterAPI.FetchClusterInfo, enum.PermissionElasticsearchMetricRead))
 
 	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/info", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.GetClusterInfo, enum.PermissionElasticsearchMetricRead)))
+	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/monitor_state", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.getClusterMonitorState, enum.PermissionElasticsearchMetricRead)))
 	api.HandleAPIMethod(api.POST, "/elasticsearch/node/_search", clusterAPI.RequirePermission(clusterAPI.SearchNodeMetadata, enum.PermissionElasticsearchNodeRead))
 	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/nodes", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.GetClusterNodes, enum.PermissionElasticsearchMetricRead, enum.PermissionElasticsearchNodeRead)))
 	api.HandleAPIMethod(api.GET, "/elasticsearch/:id/nodes/realtime", clusterAPI.RequireClusterPermission(clusterAPI.RequirePermission(clusterAPI.GetRealtimeClusterNodes, enum.PermissionElasticsearchMetricRead)))

--- a/modules/elastic/api/manage.go
+++ b/modules/elastic/api/manage.go
@@ -528,7 +528,7 @@ func (h *APIHandler) HandleMetricsSummaryAction(w http.ResponseWriter, req *http
 func (h *APIHandler) HandleClusterMetricsAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	resBody := map[string]interface{}{}
 	id := ps.ByName("id")
-	if GetMonitorState(id) == Console {
+	if GetMonitorState(id) == elastic.ModeAgentless {
 		h.APIHandler.HandleClusterMetricsAction(w, req, ps)
 		return
 	}
@@ -626,7 +626,7 @@ func (h *APIHandler) HandleNodeMetricsAction(w http.ResponseWriter, req *http.Re
 func (h *APIHandler) HandleIndexMetricsAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	resBody := map[string]interface{}{}
 	id := ps.ByName("id")
-	if GetMonitorState(id) == Console {
+	if GetMonitorState(id) == elastic.ModeAgentless {
 		h.APIHandler.HandleIndexMetricsAction(w, req, ps)
 		return
 	}

--- a/modules/elastic/api/manage.go
+++ b/modules/elastic/api/manage.go
@@ -561,9 +561,14 @@ func (h *APIHandler) HandleClusterMetricsAction(w http.ResponseWriter, req *http
 	ctx, cancel := context.WithTimeout(context.Background(), du)
 	defer cancel()
 	if util.StringInArray([]string{v1.IndexThroughputMetricKey, v1.SearchThroughputMetricKey, v1.IndexLatencyMetricKey, v1.SearchLatencyMetricKey}, key) {
-		metrics = h.GetClusterIndexMetrics(ctx, id, bucketSize, min, max, key)
+		metrics, err = h.GetClusterIndexMetrics(ctx, id, bucketSize, min, max, key)
 	}else{
-		metrics = h.GetClusterMetrics(ctx, id, bucketSize, min, max, key)
+		metrics, err = h.GetClusterMetrics(ctx, id, bucketSize, min, max, key)
+	}
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err, http.StatusInternalServerError)
+		return
 	}
 
 	resBody["metrics"] = metrics
@@ -603,7 +608,7 @@ func (h *APIHandler) HandleNodeMetricsAction(w http.ResponseWriter, req *http.Re
 	resBody["metrics"], err = h.getNodeMetrics(ctx, id, bucketSize, min, max, nodeName, top, key)
 	if err != nil {
 		log.Error(err)
-		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		h.WriteError(w, err, http.StatusInternalServerError)
 		return
 	}
 	ver := elastic.GetClient(global.MustLookupString(elastic.GlobalSystemElasticsearchID)).GetVersion()
@@ -903,35 +908,36 @@ const (
 	CircuitBreakerMetricKey = "circuit_breaker"
 )
 
-func (h *APIHandler) GetClusterMetrics(ctx context.Context, id string, bucketSize int, min, max int64, metricKey string) map[string]*common.MetricItem {
+func (h *APIHandler) GetClusterMetrics(ctx context.Context, id string, bucketSize int, min, max int64, metricKey string) (map[string]*common.MetricItem, error) {
 
-	var clusterMetricsResult = map[string]*common.MetricItem {}
+	var (
+		clusterMetricsResult = map[string]*common.MetricItem {}
+		err error
+	)
 	switch metricKey {
 	case ClusterDocumentsMetricKey,
 		ClusterStorageMetricKey,
 		ClusterIndicesMetricKey,
 		ClusterNodeCountMetricKey:
-		clusterMetricsResult = h.getClusterMetricsByKey(ctx, id, bucketSize, min, max, metricKey)
+		clusterMetricsResult, err = h.getClusterMetricsByKey(ctx, id, bucketSize, min, max, metricKey)
 	case v1.IndexLatencyMetricKey, v1.IndexThroughputMetricKey, v1.SearchThroughputMetricKey, v1.SearchLatencyMetricKey:
-		clusterMetricsResult = h.GetClusterIndexMetrics(ctx, id, bucketSize, min, max, metricKey)
+		clusterMetricsResult, err = h.GetClusterIndexMetrics(ctx, id, bucketSize, min, max, metricKey)
 	case ClusterHealthMetricKey:
-		statusMetric, err := h.getClusterStatusMetric(ctx, id, min, max, bucketSize)
+		var statusMetric *common.MetricItem
+		statusMetric, err = h.getClusterStatusMetric(ctx, id, min, max, bucketSize)
 		if err == nil {
 			clusterMetricsResult[ClusterHealthMetricKey] = statusMetric
-		} else {
-			log.Error("get cluster status metric error: ", err)
 		}
 	case ShardCountMetricKey:
-		clusterMetricsResult = h.getShardsMetric(ctx, id, min, max, bucketSize)
+		clusterMetricsResult, err = h.getShardsMetric(ctx, id, min, max, bucketSize)
 
 	case CircuitBreakerMetricKey:
-		clusterMetricsResult = h.getCircuitBreakerMetric(ctx, id, min, max, bucketSize)
+		clusterMetricsResult, err = h.getCircuitBreakerMetric(ctx, id, min, max, bucketSize)
 	}
-
-	return clusterMetricsResult
+	return clusterMetricsResult, err
 }
 
-func (h *APIHandler) getClusterMetricsByKey(ctx context.Context, id string, bucketSize int, min, max int64, metricKey string) map[string]*common.MetricItem {
+func (h *APIHandler) getClusterMetricsByKey(ctx context.Context, id string, bucketSize int, min, max int64, metricKey string) (map[string]*common.MetricItem, error) {
 	bucketSizeStr := fmt.Sprintf("%vs", bucketSize)
 
 	clusterMetricItems := []*common.MetricItem{}
@@ -964,7 +970,7 @@ func (h *APIHandler) getClusterMetricsByKey(ctx context.Context, id string, buck
 		meta := elastic.GetMetadata(id)
 		if meta == nil {
 			err := fmt.Errorf("metadata of cluster [%s] is not found", id)
-			panic(err)
+			return nil, err
 		}
 		majorVersion := meta.GetMajorVersion()
 
@@ -1024,7 +1030,7 @@ func (h *APIHandler) getClusterMetricsByKey(ctx context.Context, id string, buck
 	return h.getSingleMetrics(ctx, clusterMetricItems, query, bucketSize)
 }
 
-func (h *APIHandler) GetClusterIndexMetrics(ctx context.Context, id string, bucketSize int, min, max int64, metricKey string) map[string]*common.MetricItem {
+func (h *APIHandler) GetClusterIndexMetrics(ctx context.Context, id string, bucketSize int, min, max int64, metricKey string) (map[string]*common.MetricItem, error) {
 	bucketSizeStr := fmt.Sprintf("%vs", bucketSize)
 	metricItems := []*common.MetricItem{}
 	switch metricKey {
@@ -1081,7 +1087,7 @@ func (h *APIHandler) GetClusterIndexMetrics(ctx context.Context, id string, buck
 	query := map[string]interface{}{}
 	clusterUUID, err := adapter.GetClusterUUID(id)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	query["query"] = util.MapStr{
 		"bool": util.MapStr{
@@ -1123,7 +1129,7 @@ func (h *APIHandler) GetClusterIndexMetrics(ctx context.Context, id string, buck
 	return h.getSingleIndexMetricsByNodeStats(ctx, metricItems, query, bucketSize)
 }
 
-func (h *APIHandler) getShardsMetric(ctx context.Context, id string, min, max int64, bucketSize int) map[string]*common.MetricItem {
+func (h *APIHandler) getShardsMetric(ctx context.Context, id string, min, max int64, bucketSize int) (map[string]*common.MetricItem, error) {
 	bucketSizeStr := fmt.Sprintf("%vs", bucketSize)
 	query := util.MapStr{
 		"query": util.MapStr{
@@ -1185,7 +1191,7 @@ func (h *APIHandler) getShardsMetric(ctx context.Context, id string, min, max in
 	return h.getSingleMetrics(ctx, clusterHealthMetrics, query, bucketSize)
 }
 
-func (h *APIHandler) getCircuitBreakerMetric(ctx context.Context, id string, min, max int64, bucketSize int) map[string]*common.MetricItem {
+func (h *APIHandler) getCircuitBreakerMetric(ctx context.Context, id string, min, max int64, bucketSize int) (map[string]*common.MetricItem, error) {
 	bucketSizeStr := fmt.Sprintf("%vs", bucketSize)
 	query := util.MapStr{
 		"query": util.MapStr{

--- a/modules/elastic/api/monitor_state.go
+++ b/modules/elastic/api/monitor_state.go
@@ -32,18 +32,13 @@ import (
 	"infini.sh/framework/core/elastic"
 )
 
-type MonitorState int
-const (
-	Console MonitorState = iota
-	Agent
-)
-func GetMonitorState(clusterID string) MonitorState {
+func GetMonitorState(clusterID string) string {
 	conf := elastic.GetConfig(clusterID)
 	if conf == nil {
 		panic(fmt.Errorf("config of cluster [%s] is not found", clusterID))
 	}
 	if conf.MonitorConfigs != nil && !conf.MonitorConfigs.NodeStats.Enabled && !conf.MonitorConfigs.IndexStats.Enabled {
-		return Agent
+		return elastic.ModeAgent
 	}
-	return Console
+	return elastic.ModeAgentless
 }

--- a/modules/elastic/api/node_metrics.go
+++ b/modules/elastic/api/node_metrics.go
@@ -1122,7 +1122,7 @@ func (h *APIHandler) getNodeMetrics(ctx context.Context, clusterID string, bucke
 			},
 		},
 	}
-	return h.getMetrics(ctx, query, nodeMetricItems, bucketSize), nil
+	return h.getMetrics(ctx, query, nodeMetricItems, bucketSize)
 
 }
 

--- a/modules/elastic/api/node_overview.go
+++ b/modules/elastic/api/node_overview.go
@@ -1276,7 +1276,7 @@ func (h *APIHandler) getLatestIndices(req *http.Request, min string, max string,
 
 func (h *APIHandler) GetNodeShards(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	clusterID := ps.MustGetParameter("id")
-	if GetMonitorState(clusterID) == Console {
+	if GetMonitorState(clusterID) == elastic.ModeAgentless {
 		h.APIHandler.GetNodeShards(w, req, ps)
 		return
 	}

--- a/modules/elastic/api/node_overview.go
+++ b/modules/elastic/api/node_overview.go
@@ -422,7 +422,12 @@ func (h *APIHandler) FetchNodeInfo(w http.ResponseWriter, req *http.Request, ps 
 			},
 		},
 	}
-	metrics := h.getMetrics(ctx, query, nodeMetricItems, bucketSize)
+	metrics, err := h.getMetrics(ctx, query, nodeMetricItems, bucketSize)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err, http.StatusInternalServerError)
+		return
+	}
 	indexMetrics := map[string]util.MapStr{}
 	for key, item := range metrics {
 		for _, line := range item.Lines {
@@ -787,7 +792,12 @@ func (h *APIHandler) GetSingleNodeMetrics(w http.ResponseWriter, req *http.Reque
 			metricItems=append(metricItems,metricItem)
 		}
 
-		metrics = h.getSingleMetrics(ctx, metricItems,query, bucketSize)
+		metrics, err = h.getSingleMetrics(ctx, metricItems,query, bucketSize)
+		if err != nil {
+			log.Error(err)
+			h.WriteError(w, err, http.StatusInternalServerError)
+			return
+		}
 	}
 
 	resBody["metrics"] = metrics

--- a/modules/elastic/api/threadpool_metrics.go
+++ b/modules/elastic/api/threadpool_metrics.go
@@ -636,5 +636,5 @@ func (h *APIHandler) getThreadPoolMetrics(ctx context.Context, clusterID string,
 			},
 		},
 	}
-	return h.getMetrics(ctx, query, queueMetricItems, bucketSize), nil
+	return h.getMetrics(ctx, query, queueMetricItems, bucketSize)
 }

--- a/modules/elastic/api/v1/index_overview.go
+++ b/modules/elastic/api/v1/index_overview.go
@@ -236,7 +236,12 @@ func (h *APIHandler) FetchIndexInfo(w http.ResponseWriter, ctx context.Context, 
 			},
 		},
 	}
-	metrics := h.getMetrics(ctx, query, nodeMetricItems, bucketSize)
+	metrics, err := h.getMetrics(ctx, query, nodeMetricItems, bucketSize)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err, http.StatusInternalServerError)
+		return
+	}
 	indexMetrics := map[string]util.MapStr{}
 	for key, item := range metrics {
 		for _, line := range item.Lines {
@@ -565,7 +570,12 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 			}
 			metricItems = append(metricItems, metricItem)
 		}
-		metrics = h.getSingleMetrics(ctx, metricItems, query, bucketSize)
+		metrics, err = h.getSingleMetrics(ctx, metricItems, query, bucketSize)
+		if err != nil {
+			log.Error(err)
+			h.WriteError(w, err, http.StatusInternalServerError)
+			return
+		}
 	}
 	resBody["metrics"] = metrics
 	h.WriteJSON(w, resBody, http.StatusOK)


### PR DESCRIPTION
## What does this PR do
- add api `collection stats` to visit current cluster metric collection stats
GET /elasticsearch/:cluster_id/_collection_stats
{
  "cluster_health": {
    "last_active_at": 1734008183649,
    "status": "ok"
  },
  "cluster_id": "infini_default_system_cluster",
  "cluster_stats": {
    "last_active_at": 1734008183707,
    "status": "ok"
  },
  "index_stats": {
    "last_active_at": 1734008183743,
    "status": "ok"
  },
  "metric_collection_mode": "agentless",
  "node_stats": {
    "last_active_at": 1734008183698,
    "status": "ok"
  }
}

- fix empty index metrics in overview info api when collection mode is agentless

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Performance tests checked, no obvious performance degradation
- [ ] Necessary documents have been added if this is a new feature