### PR TITLE
chore: adapter node metrics query with `cluster_id ` or `cluster uuid`

### DIFF
--- a/modules/elastic/api/cluster_overview.go
+++ b/modules/elastic/api/cluster_overview.go
@@ -566,9 +566,23 @@ func (h *APIHandler) GetClusterNodes(w http.ResponseWriter, req *http.Request, p
 						},
 					},
 					{
-						"term": util.MapStr{
-							"metadata.labels.cluster_uuid": util.MapStr{
-								"value": clusterUUID,
+						"bool": util.MapStr{
+							"minimum_should_match": 1,
+							"should": []util.MapStr{
+								{
+									"term": util.MapStr{
+										"metadata.labels.cluster_id": util.MapStr{
+											"value": id,
+										},
+									},
+								},
+								{
+									"term": util.MapStr{
+										"metadata.labels.cluster_uuid": util.MapStr{
+											"value": clusterUUID,
+										},
+									},
+								},
 							},
 						},
 					},

--- a/modules/elastic/api/node_metrics.go
+++ b/modules/elastic/api/node_metrics.go
@@ -117,9 +117,23 @@ func (h *APIHandler) getNodeMetrics(ctx context.Context, clusterID string, bucke
 
 	var must = []util.MapStr{
 		{
-			"term":util.MapStr{
-				"metadata.labels.cluster_uuid":util.MapStr{
-					"value": clusterUUID,
+			"bool": util.MapStr{
+				"minimum_should_match": 1,
+				"should": []util.MapStr{
+					{
+						"term": util.MapStr{
+							"metadata.labels.cluster_id": util.MapStr{
+								"value": clusterID,
+							},
+						},
+					},
+					{
+						"term": util.MapStr{
+							"metadata.labels.cluster_uuid": util.MapStr{
+								"value": clusterUUID,
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## What does this PR do
adapter node metrics query with `cluster_id ` or `cluster uuid`
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Performance tests checked, no obvious performance degradation
- [ ] Necessary documents have been added if this is a new feature