### PR TITLE
fix: lose `Copy As Curl` in `Dev Tools`

### DIFF
--- a/web/src/components/vendor/console/components/ConsoleMenu.tsx
+++ b/web/src/components/vendor/console/components/ConsoleMenu.tsx
@@ -45,6 +45,7 @@ import { saveCommonCommand } from "../modules/es";
 import { pushCommand } from "../modules/mappings/mappings";
 import { formatMessage } from "umi/locale";
 import { hasAuthority } from "@/utils/authority";
+import { CopyToClipboard } from "react-copy-to-clipboard";
 
 interface Props {
   getCurl: () => Promise<string>;
@@ -177,21 +178,22 @@ export default class ConsoleMenu extends Component<Props, State> {
         {formatMessage({ id: "console.menu.save_as_command" })}
       </EuiContextMenuItem>)
     }
-    if (window.navigator?.clipboard) {
-      items.unshift(
+    items.unshift(
+      <CopyToClipboard key="Copy as cURL" text={this.state.curlCode}>
         <EuiContextMenuItem
-          key="Copy as cURL"
           id="ConCopyAsCurl"
-          disabled={!window.navigator?.clipboard}
           onClick={() => {
             this.closePopover();
-            this.copyAsCurl();
+            notification.open({
+              message: "Request copied as cURL",
+              placement: "bottomRight",
+            });
           }}
         >
           {formatMessage({ id: "console.menu.copy_as_curl" })}
         </EuiContextMenuItem>
-      );
-    }
+      </CopyToClipboard>
+    );
 
     return (
       <span onMouseEnter={this.mouseEnter}>


### PR DESCRIPTION
## What does this PR do
1. fix: lose `Copy As Curl` in `Dev Tools`

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Performance tests checked, no obvious performance degradation
- [ ] Necessary documents have been added if this is a new feature