### PR TITLE
feat: add api to clean unavailable index, node metadata

### DIFF
--- a/modules/elastic/api/init.go
+++ b/modules/elastic/api/init.go
@@ -131,5 +131,7 @@ func init() {
 
 	api.HandleAPIMethod(api.GET, "/elasticsearch/metadata", clusterAPI.RequireLogin(clusterAPI.GetMetadata))
 	api.HandleAPIMethod(api.GET, "/elasticsearch/hosts", clusterAPI.RequireLogin(clusterAPI.GetHosts))
+	api.HandleAPIMethod(api.DELETE, "/elasticsearch/metadata/index", clusterAPI.RequireLogin(clusterAPI.deleteIndexMetadata))
+	api.HandleAPIMethod(api.DELETE, "/elasticsearch/metadata/node", clusterAPI.RequireLogin(clusterAPI.deleteNodeMetadata))
 
 }


### PR DESCRIPTION
## What does this PR do
add api to clean unavailable index, node metadata
- DELETE /elasticsearch/metadata/index
 used to delete index metadata after index is deleted from cluster
- DELETE /elasticsearch/metadata/node
used to clean node metadata after node is offline and not active within 7 days

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Performance tests checked, no obvious performance degradation
- [ ] Necessary documents have been added if this is a new feature