### PR TITLE
fix: query thread pool metrics when cluster uuid is empty

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -7,6 +7,17 @@ title: "Release Notes"
 
 Information about release notes of INFINI Console is provided here.
 
+## 1.27.1 (2024-12-18)
+### Bug fix
+- fix: query thread pool metrics when cluster uuid is empty
+
+## 1.27.0 (2024-12-09)
+
+### Improvements
+- Split monitoring metric requests to optimize monitoring metric query response speed.
+- Fixed node and index metadata ID to prevent metadata record duplication.
+- Optimizing ES metric collecting
+
 ## 1.26.1 (2024-08-13)
 
 ### Improvements

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,8 +15,21 @@ Information about release notes of INFINI Console is provided here.
 
 ### Improvements
 - Split monitoring metric requests to optimize monitoring metric query response speed.
-- Fixed node and index metadata ID to prevent metadata record duplication.
 - Optimizing ES metric collecting
+- The code is open source and the Github repository is used for development
+- Added timeout setting to general time component
+- Cluster selection component adds registration and refresh feature
+- Adding metrics collection status
+- Optimizing layout of table component
+
+### Bug fix
+- Fixed the issue of untimely update of cluster metadata
+- Fixed the issue of incorrect links in help documents, etc.
+- Fixed node and index metadata ID to prevent metadata record duplication.
+- Fixed the issue of errors in Runtime and Agent instance editing pages
+- Fixed the issue of no loading of cluster, node, index, and shard metadata
+- Fixed the issue of failure to collect index health status indicators
+- Fixed the issue of some menu columns not being internationalized
 
 ## 1.26.1 (2024-08-13)
 

--- a/modules/elastic/api/threadpool_metrics.go
+++ b/modules/elastic/api/threadpool_metrics.go
@@ -89,13 +89,6 @@ func (h *APIHandler) getThreadPoolMetrics(ctx context.Context, clusterID string,
 	bucketSizeStr:=fmt.Sprintf("%vs",bucketSize)
 	var must = []util.MapStr{
 		{
-			"term":util.MapStr{
-				"metadata.labels.cluster_uuid":util.MapStr{
-					"value": clusterUUID,
-				},
-			},
-		},
-		{
 			"term": util.MapStr{
 				"metadata.category": util.MapStr{
 					"value": "elasticsearch",
@@ -147,6 +140,23 @@ func (h *APIHandler) getThreadPoolMetrics(ctx context.Context, clusterID string,
 	query["query"]=util.MapStr{
 		"bool": util.MapStr{
 			"must": must,
+			"minimum_should_match": 1,
+			"should": []util.MapStr{
+				{
+					"term":util.MapStr{
+						"metadata.labels.cluster_id":util.MapStr{
+							"value": clusterID,
+						},
+					},
+				},
+				{
+					"term":util.MapStr{
+						"metadata.labels.cluster_uuid":util.MapStr{
+							"value": clusterUUID,
+						},
+					},
+				},
+			},
 			"filter": []util.MapStr{
 				{
 					"range": util.MapStr{


### PR DESCRIPTION
## What does this PR do
fix query thread pool metrics when cluster uuid is empty 
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation