### PR TITLE
chore: adapter metrics query with cluster id and cluster uuid

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,14 +12,15 @@ Information about release notes of INFINI Console is provided here.
 ### Breaking changes
 
 ### Features
-- add allocation to activities if is cluster health change and changed to red.
+- Add allocation to activities if is cluster health change and changed to red.
 
 ### Bug fix
-- fix: query thread pool metrics when cluster uuid is empty
+- Fix: query thread pool metrics when cluster uuid is empty
 
 ### Improvements
 - Optimize UI of agent list when its columns are overflow.
-- add loading to each row in overview table.
+- Add loading to each row in overview table.
+- Adapter metrics query with cluster id and cluster uuid
 
 ## 1.27.0 (2024-12-09)
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,7 +15,7 @@ Information about release notes of INFINI Console is provided here.
 - Add allocation to activities if is cluster health change and changed to red.
 
 ### Bug fix
-- Fix: query thread pool metrics when cluster uuid is empty
+- Fix query thread pool metrics when cluster uuid is empty
 
 ### Improvements
 - Optimize UI of agent list when its columns are overflow.

--- a/modules/elastic/api/node_metrics.go
+++ b/modules/elastic/api/node_metrics.go
@@ -112,29 +112,32 @@ func (h *APIHandler) getNodeMetrics(ctx context.Context, clusterID string, bucke
 	bucketSizeStr:=fmt.Sprintf("%vs",bucketSize)
 	clusterUUID, err := adapter.GetClusterUUID(clusterID)
 	if err != nil {
-		return nil, err
+		log.Warnf("get cluster uuid with cluster [%s] error:%v", clusterID, err)
 	}
 
+	should := []util.MapStr{
+		{
+			"term": util.MapStr{
+				"metadata.labels.cluster_id": util.MapStr{
+					"value": clusterID,
+				},
+			},
+		},
+	}
+	if clusterUUID != "" {
+		should = append(should, util.MapStr{
+			"term": util.MapStr{
+				"metadata.labels.cluster_uuid": util.MapStr{
+					"value": clusterUUID,
+				},
+			},
+		})
+	}
 	var must = []util.MapStr{
 		{
 			"bool": util.MapStr{
 				"minimum_should_match": 1,
-				"should": []util.MapStr{
-					{
-						"term": util.MapStr{
-							"metadata.labels.cluster_id": util.MapStr{
-								"value": clusterID,
-							},
-						},
-					},
-					{
-						"term": util.MapStr{
-							"metadata.labels.cluster_uuid": util.MapStr{
-								"value": clusterUUID,
-							},
-						},
-					},
-				},
+				"should": should,
 			},
 		},
 		{

--- a/modules/elastic/api/node_metrics.go
+++ b/modules/elastic/api/node_metrics.go
@@ -30,7 +30,6 @@ import (
 	"infini.sh/framework/core/elastic"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
-	"infini.sh/framework/modules/elastic/adapter"
 	"infini.sh/framework/modules/elastic/common"
 	"sort"
 	"strings"
@@ -110,9 +109,9 @@ const (
 
 func (h *APIHandler) getNodeMetrics(ctx context.Context, clusterID string, bucketSize int, min, max int64, nodeName string, top int, metricKey string) (map[string]*common.MetricItem, error){
 	bucketSizeStr:=fmt.Sprintf("%vs",bucketSize)
-	clusterUUID, err := adapter.GetClusterUUID(clusterID)
+	clusterUUID, err := h.getClusterUUID(clusterID)
 	if err != nil {
-		log.Warnf("get cluster uuid with cluster [%s] error:%v", clusterID, err)
+		return nil, err
 	}
 
 	should := []util.MapStr{
@@ -123,15 +122,13 @@ func (h *APIHandler) getNodeMetrics(ctx context.Context, clusterID string, bucke
 				},
 			},
 		},
-	}
-	if clusterUUID != "" {
-		should = append(should, util.MapStr{
+		{
 			"term": util.MapStr{
 				"metadata.labels.cluster_uuid": util.MapStr{
 					"value": clusterUUID,
 				},
 			},
-		})
+		},
 	}
 	var must = []util.MapStr{
 		{

--- a/modules/elastic/api/threadpool_metrics.go
+++ b/modules/elastic/api/threadpool_metrics.go
@@ -30,7 +30,6 @@ import (
 	"infini.sh/framework/core/elastic"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
-	"infini.sh/framework/modules/elastic/adapter"
 	"infini.sh/framework/modules/elastic/common"
 	"strings"
 )
@@ -82,9 +81,9 @@ const (
 )
 
 func (h *APIHandler) getThreadPoolMetrics(ctx context.Context, clusterID string, bucketSize int, min, max int64, nodeName string, top int, metricKey string) (map[string]*common.MetricItem, error){
-	clusterUUID, err := adapter.GetClusterUUID(clusterID)
+	clusterUUID, err := h.getClusterUUID(clusterID)
 	if err != nil {
-		log.Warnf("get cluster uuid with cluster [%s] error: %v", clusterID, err)
+		return nil, err
 	}
 	bucketSizeStr:=fmt.Sprintf("%vs",bucketSize)
 	var must = []util.MapStr{
@@ -143,15 +142,13 @@ func (h *APIHandler) getThreadPoolMetrics(ctx context.Context, clusterID string,
 				},
 			},
 		},
-	}
-	if clusterUUID != "" {
-		should = append(should, util.MapStr{
+		{
 			"term":util.MapStr{
 				"metadata.labels.cluster_uuid":util.MapStr{
 					"value": clusterUUID,
 				},
 			},
-		})
+		},
 	}
 
 	query:=map[string]interface{}{}


### PR DESCRIPTION
## What does this PR do
adapter metrics query with cluster id and cluster uuid
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation