### PR TITLE
optimize metric query bucket size

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -21,6 +21,7 @@ Information about release notes of INFINI Console is provided here.
 - Optimize UI of agent list when its columns are overflow.
 - Add loading to each row in overview table.
 - Adapter metrics query with cluster id and cluster uuid
+- Optimize metric query bucket size (#59)
 
 
 ## 1.27.0 (2024-12-09)

--- a/modules/elastic/api/host.go
+++ b/modules/elastic/api/host.go
@@ -466,7 +466,7 @@ func (h *APIHandler) FetchHostInfo(w http.ResponseWriter, req *http.Request, ps 
 		return
 	}
 
-	bucketSize, min, max, err := h.getMetricRangeAndBucketSize(req, 60, 15)
+	bucketSize, min, max, err := h.GetMetricRangeAndBucketSize(req, "", "", 15)
 	if err != nil {
 		panic(err)
 		return
@@ -712,7 +712,7 @@ func (h *APIHandler) GetSingleHostMetrics(w http.ResponseWriter, req *http.Reque
 	}
 
 	resBody := map[string]interface{}{}
-	bucketSize, min, max, err := h.getMetricRangeAndBucketSize(req, 10, 60)
+	bucketSize, min, max, err := h.GetMetricRangeAndBucketSize(req, "", "", 60)
 	if err != nil {
 		log.Error(err)
 		resBody["error"] = err

--- a/modules/elastic/api/index_overview.go
+++ b/modules/elastic/api/index_overview.go
@@ -883,7 +883,15 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 		})
 	}
 	resBody := map[string]interface{}{}
-	bucketSize, min, max, err := h.getMetricRangeAndBucketSize(req, 10, 60)
+	metricKey := h.GetParameter(req, "key")
+	var metricType string
+	if metricKey == v1.IndexHealthMetricKey {
+		metricType = v1.MetricTypeClusterHealth
+	}else{
+		//for agent mode
+		metricType = v1.MetricTypeNodeStats
+	}
+	bucketSize, min, max, err := h.GetMetricRangeAndBucketSize(req, clusterID, metricType,60)
 	if err != nil {
 		log.Error(err)
 		resBody["error"] = err
@@ -893,7 +901,6 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 	if bucketSize <= 60 {
 		min = min - int64(2 * bucketSize * 1000)
 	}
-	metricKey := h.GetParameter(req, "key")
 	timeout := h.GetParameterOrDefault(req, "timeout", "60s")
 	du, err := time.ParseDuration(timeout)
 	if err != nil {

--- a/modules/elastic/api/metrics_util.go
+++ b/modules/elastic/api/metrics_util.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"fmt"
 	"infini.sh/framework/core/env"
-	"net/http"
 	"strings"
 	"time"
 
@@ -232,36 +231,6 @@ func GetMinBucketSize() int {
 		metricsCfg.MinBucketSizeInSeconds = 20
 	}
 	return metricsCfg.MinBucketSizeInSeconds
-}
-
-// defaultBucketSize 也就是每次聚合的时间间隔
-func (h *APIHandler) getMetricRangeAndBucketSize(req *http.Request, defaultBucketSize, defaultMetricCount int) (int, int64, int64, error) {
-	minBucketSizeInSeconds := GetMinBucketSize()
-	if defaultBucketSize <= 0 {
-		defaultBucketSize = minBucketSizeInSeconds
-	}
-	if defaultMetricCount <= 0 {
-		defaultMetricCount = 15 * 60
-	}
-	bucketSize := defaultBucketSize
-
-	bucketSizeStr := h.GetParameterOrDefault(req, "bucket_size", "")    //默认 10，每个 bucket 的时间范围，单位秒
-	if bucketSizeStr != "" {
-		du, err := util.ParseDuration(bucketSizeStr)
-		if err != nil {
-			return 0, 0, 0, err
-		}
-		bucketSize = int(du.Seconds())
-	}else {
-		bucketSize = 0
-	}
-	metricCount := h.GetIntOrDefault(req, "metric_count", defaultMetricCount) //默认 15分钟的区间，每分钟15个指标，也就是 15*6 个 bucket //90
-	//min,max are unix nanoseconds
-
-	minStr := h.Get(req, "min", "")
-	maxStr := h.Get(req, "max", "")
-
-	return GetMetricRangeAndBucketSize(minStr, maxStr, bucketSize, metricCount)
 }
 
 func GetMetricRangeAndBucketSize(minStr string, maxStr string, bucketSize int, metricCount int) (int, int64, int64, error) {

--- a/modules/elastic/api/metrics_util.go
+++ b/modules/elastic/api/metrics_util.go
@@ -196,6 +196,7 @@ func (h *APIHandler) getMetrics(ctx context.Context, query map[string]interface{
 
 	result := map[string]*common.MetricItem{}
 
+	hitsTotal := response.GetTotal()
 	for _, metricItem := range grpMetricItems {
 		for _, line := range metricItem.MetricItem.Lines {
 			line.TimeRange = common.TimeRange{Min: minDate, Max: maxDate}
@@ -215,6 +216,7 @@ func (h *APIHandler) getMetrics(ctx context.Context, query map[string]interface{
 			}
 		}
 		metricItem.MetricItem.Request = string(queryDSL)
+		metricItem.MetricItem.HitsTotal = hitsTotal
 		result[metricItem.Key] = metricItem.MetricItem
 	}
 	return result, nil
@@ -438,6 +440,7 @@ func (h *APIHandler) getSingleMetrics(ctx context.Context, metricItems []*common
 			}
 		}
 		metricItem.Request = string(queryDSL)
+		metricItem.HitsTotal = response.GetTotal()
 		result[metricItem.Key] = metricItem
 	}
 
@@ -1182,6 +1185,7 @@ func parseSingleIndexMetrics(ctx context.Context, clusterID string, metricItems 
 			}
 		}
 		metricItem.Request = string(queryDSL)
+		metricItem.HitsTotal = response.GetTotal()
 		result[metricItem.Key] = metricItem
 	}
 

--- a/modules/elastic/api/node_overview.go
+++ b/modules/elastic/api/node_overview.go
@@ -632,7 +632,7 @@ func (h *APIHandler) GetSingleNodeMetrics(w http.ResponseWriter, req *http.Reque
 		},
 	}
 	resBody := map[string]interface{}{}
-	bucketSize, min, max, err := h.getMetricRangeAndBucketSize(req,10,60)
+	bucketSize, min, max, err := h.GetMetricRangeAndBucketSize(req,clusterID, v1.MetricTypeNodeStats,60)
 	if err != nil {
 		log.Error(err)
 		resBody["error"] = err

--- a/modules/elastic/api/node_overview.go
+++ b/modules/elastic/api/node_overview.go
@@ -803,6 +803,16 @@ func (h *APIHandler) GetSingleNodeMetrics(w http.ResponseWriter, req *http.Reque
 			return
 		}
 	}
+	if _, ok := metrics[metricKey]; ok {
+		if metrics[metricKey].HitsTotal > 0 {
+			minBucketSize, err := v1.GetMetricMinBucketSize(clusterID, v1.MetricTypeNodeStats)
+			if err != nil {
+				log.Error(err)
+			}else{
+				metrics[metricKey].MinBucketSize = int64(minBucketSize)
+			}
+		}
+	}
 
 	resBody["metrics"] = metrics
 	h.WriteJSON(w, resBody, http.StatusOK)

--- a/modules/elastic/api/v1/cluster_overview.go
+++ b/modules/elastic/api/v1/cluster_overview.go
@@ -110,7 +110,7 @@ func (h *APIHandler) FetchClusterInfo(w http.ResponseWriter, req *http.Request, 
 	}
 
 	//fetch cluster metrics
-	bucketSize, min, max, err := h.getMetricRangeAndBucketSize(req, 60, (15))
+	bucketSize, min, max, err := h.GetMetricRangeAndBucketSize(req, clusterIDs[0], MetricTypeIndexStats, 15)
 	if err != nil {
 		panic(err)
 		return

--- a/modules/elastic/api/v1/index_overview.go
+++ b/modules/elastic/api/v1/index_overview.go
@@ -469,19 +469,12 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 		},
 	}
 	resBody := map[string]interface{}{}
-	bucketSize, min, max, err := h.getMetricRangeAndBucketSize(req, 10, 60)
+	bucketSize, min, max, err := h.GetMetricRangeAndBucketSize(req, clusterID, MetricTypeIndexStats, 60)
 	if err != nil {
 		log.Error(err)
 		resBody["error"] = err
 		h.WriteJSON(w, resBody, http.StatusInternalServerError)
 		return
-	}
-	meta := elastic.GetMetadata(clusterID)
-	if meta != nil && meta.Config.MonitorConfigs != nil && meta.Config.MonitorConfigs.IndexStats.Interval != "" {
-		du, _ := time.ParseDuration(meta.Config.MonitorConfigs.IndexStats.Interval)
-		if bucketSize < int(du.Seconds()) {
-			bucketSize = int(du.Seconds())
-		}
 	}
 	query := map[string]interface{}{}
 	query["query"] = util.MapStr{

--- a/modules/elastic/api/v1/index_overview.go
+++ b/modules/elastic/api/v1/index_overview.go
@@ -570,6 +570,16 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 			return
 		}
 	}
+	if _, ok := metrics[metricKey]; ok {
+		if metrics[metricKey].HitsTotal > 0 {
+			minBucketSize, err := GetMetricMinBucketSize(clusterID, MetricTypeIndexStats)
+			if err != nil {
+				log.Error(err)
+			}else{
+				metrics[metricKey].MinBucketSize = int64(minBucketSize)
+			}
+		}
+	}
 	resBody["metrics"] = metrics
 	h.WriteJSON(w, resBody, http.StatusOK)
 }
@@ -662,6 +672,7 @@ func (h *APIHandler) GetIndexHealthMetric(ctx context.Context, id, indexName str
 	metricItem.Lines[0].Data = metricData
 	metricItem.Lines[0].Type = common.GraphTypeBar
 	metricItem.Request = string(queryDSL)
+	metricItem.HitsTotal = response.GetTotal()
 	return metricItem, nil
 }
 

--- a/modules/elastic/api/v1/metrics_util.go
+++ b/modules/elastic/api/v1/metrics_util.go
@@ -197,6 +197,7 @@ func (h *APIHandler) getMetrics(ctx context.Context, query map[string]interface{
 
 	result := map[string]*common.MetricItem{}
 
+	hitsTotal := response.GetTotal()
 	for _, metricItem := range grpMetricItems {
 		for _, line := range metricItem.MetricItem.Lines {
 			line.TimeRange = common.TimeRange{Min: minDate, Max: maxDate}
@@ -207,6 +208,7 @@ func (h *APIHandler) getMetrics(ctx context.Context, query map[string]interface{
 			line.Data = grpMetricData[dataKey][line.Metric.Label]
 		}
 		metricItem.MetricItem.Request = string(queryDSL)
+		metricItem.MetricItem.HitsTotal = hitsTotal
 		result[metricItem.Key] = metricItem.MetricItem
 	}
 	return result, nil
@@ -231,7 +233,7 @@ const (
 	MetricTypeNodeStats      = "node_stats"
 	MetricTypeIndexStats     = "index_stats"
 )
-//GetMetricMinBucketSize returns the metrics collection interval based on the cluster ID and metric type
+//GetMetricMinBucketSize returns twice the metrics collection interval based on the cluster ID and metric type
 func GetMetricMinBucketSize(clusterID, metricType string) (int, error) {
 	meta := elastic.GetMetadata(clusterID)
 	if meta == nil {
@@ -500,12 +502,14 @@ func (h *APIHandler) getSingleMetrics(ctx context.Context, metricItems []*common
 
 	result := map[string]*common.MetricItem{}
 
+	hitsTotal := response.GetTotal()
 	for _, metricItem := range metricItems {
 		for _, line := range metricItem.Lines {
 			line.TimeRange = common.TimeRange{Min: minDate, Max: maxDate}
 			line.Data = metricData[line.Metric.GetDataKey()]
 		}
 		metricItem.Request = string(queryDSL)
+		metricItem.HitsTotal = hitsTotal
 		result[metricItem.Key] = metricItem
 	}
 

--- a/modules/elastic/api/v1/node_overview.go
+++ b/modules/elastic/api/v1/node_overview.go
@@ -619,13 +619,6 @@ func (h *APIHandler) GetSingleNodeMetrics(w http.ResponseWriter, req *http.Reque
 		h.WriteJSON(w, resBody, http.StatusInternalServerError)
 		return
 	}
-	meta := elastic.GetMetadata(clusterID)
-	if meta != nil && meta.Config.MonitorConfigs != nil && meta.Config.MonitorConfigs.NodeStats.Interval != "" {
-		du, _ := time.ParseDuration(meta.Config.MonitorConfigs.NodeStats.Interval)
-		if bucketSize < int(du.Seconds()) {
-			bucketSize = int(du.Seconds())
-		}
-	}
 	query:=map[string]interface{}{}
 	query["query"]=util.MapStr{
 		"bool": util.MapStr{


### PR DESCRIPTION
## What does this PR do
- the automatically calculated bucket size should be at least twice the metrics collection interval
- return the hit count and the minimum bucket size when querying metrics

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation