### PR TITLE
chore: check if the cluster version supports metric `transport_outbound_comnections` in monitor

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -22,6 +22,7 @@ Information about release notes of INFINI Console is provided here.
 - Add loading to each row in overview table.
 - Adapter metrics query with cluster id and cluster uuid
 - Add suggestion to chart in monitor if is no data because the time interval is less than the collection interval.
+- check if the cluster version supports metric transport_outbound_comnections in monitor.
 
 
 ## 1.27.0 (2024-12-09)

--- a/web/src/components/Overview/Monitor/index.jsx
+++ b/web/src/components/Overview/Monitor/index.jsx
@@ -84,7 +84,7 @@ const Monitor = (props) => {
     })
   );
 
-  const [refresh, setRefresh] = useState({ isRefreshPaused: allTimeSettingsCache.isRefreshPaused || false, refreshInterval: allTimeSettingsCache.refreshInterval || 30000 });
+  const [refresh, setRefresh] = useState({ isRefreshPaused: typeof allTimeSettingsCache.isRefreshPaused !== 'undefined' ? allTimeSettingsCache.isRefreshPaused : true, refreshInterval: allTimeSettingsCache.refreshInterval || 30000 });
   const [timeZone, setTimeZone] = useState(() => allTimeSettingsCache.timeZone || getTimezone());
 
   useEffect(() => {

--- a/web/src/pages/Agent/Instance/components/RowDetail.jsx
+++ b/web/src/pages/Agent/Instance/components/RowDetail.jsx
@@ -366,7 +366,7 @@ export const AgentRowDetail = ({ agentID, t }) => {
         }}
         tabBarExtraContent={
           <div style={{ display: "flex", gap: 10 }}>
-            {state.processesTab == "unknown" ? (
+            {hasAuthority("agent.instance:all") && state.processesTab === "unknown" ? (
               <Button
                 type="primary"
                 onClick={() => {

--- a/web/src/pages/Platform/Overview/Node/Monitor/advanced.jsx
+++ b/web/src/pages/Platform/Overview/Node/Monitor/advanced.jsx
@@ -4,7 +4,7 @@ import NodeMetric from "../../components/node_metric";
 import QueueMetric from "../../components/queue_metric";
 import { formatMessage } from "umi/locale";
 import { SearchEngines } from "@/lib/search_engines";
-import { isVersionGTE6, shouldHaveModelInferenceBreaker } from "../../Cluster/Monitor/advanced";
+import { checkMetric } from "../../Cluster/Monitor/advanced";
 
 export default (props) => {
 
@@ -13,14 +13,6 @@ export default (props) => {
     clusterID,
     nodeID,
   } = props
-
-  const isVersionGTE8_6 = useMemo(() => {
-    return shouldHaveModelInferenceBreaker(selectedCluster)
-  }, [selectedCluster])
-
-  const versionGTE6 = useMemo(() => {
-    return isVersionGTE6(selectedCluster)
-  }, [selectedCluster])
 
   const [param, setParam] = useState({
     show_top: false,
@@ -106,7 +98,7 @@ export default (props) => {
                     "fielddata_breaker",
                     "request_breaker",
                     "in_flight_requests_breaker",
-                    isVersionGTE8_6 ? "model_inference_breaker" : undefined
+                    checkMetric("model_inference_breaker", selectedCluster) ? "model_inference_breaker" : undefined
                 ].filter((item) => !!item)
             ],
             [
@@ -124,8 +116,8 @@ export default (props) => {
                     "transport_rx_rate",
                     "transport_tx_bytes",
                     "transport_tx_rate",
-                    "transport_outbound_connections"
-                ]
+                    checkMetric("transport_outbound_connections", selectedCluster) ? "transport_outbound_connections" : undefined
+                ].filter((item) => !!item)
             ],
             [
                 "storage",
@@ -201,7 +193,7 @@ export default (props) => {
           param={param}
           setParam={setParam}
           metrics={[
-            versionGTE6 ? [
+            checkMetric("thread_pool_write", selectedCluster) ? [
                 "thread_pool_write",
                 [
                     "write_active",
@@ -227,7 +219,7 @@ export default (props) => {
                     "search_threads"
                 ]
             ],
-            !versionGTE6 ? [
+            checkMetric("thread_pool_bulk", selectedCluster) ? [
                 "thread_pool_bulk",
                 [
                   "bulk_active",


### PR DESCRIPTION
## What does this PR do
1. check if the cluster version supports metric `transport_outbound_comnections`
2. auto refresh turn off by default

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation