### PR TITLE
chore: add some metrics to index's monitor

### DIFF
--- a/web/src/locales/en-US/cluster.js
+++ b/web/src/locales/en-US/cluster.js
@@ -152,6 +152,7 @@ export default {
   "cluster.metrics.axis.node_health.title": "Node Health",
   "cluster.metrics.axis.parent_breaker.title": "Circuit Breaker",
   "cluster.metrics.axis.circuit_breaker.title": "Circuit Breaker",
+  "cluster.metrics.axis.segment_memory.title": "Segment",
 
   "cluster.metrics.node.axis.cpu.title": "Process CPU Usage",
   "cluster.metrics.node.axis.disk.title": "Disk Available",
@@ -253,6 +254,10 @@ export default {
   "cluster.metrics.index.axis.segment_term_vectors_memory.title":
     "Term Vectors",
   "cluster.metrics.index.axis.segment_index_writer_memory.title": "IndexWriter",
+  "cluster.metrics.index.axis.segment_norms_memory.title": "Segment Norms Memory",
+  "cluster.metrics.index.axis.segment_points_memory.title": "Segment Points Memory",
+  "cluster.metrics.index.axis.segment_version_map.title": "Segment Version Map",
+  "cluster.metrics.index.axis.segment_fixed_bit_set.title": "Segment Fixed Bit Set",
   "cluster.metrics.node.axis.total_io_operations.title":
     "Total I/O  Operations Rate",
   "cluster.metrics.node.axis.total_read_io_operations.title":

--- a/web/src/locales/zh-CN/cluster.js
+++ b/web/src/locales/zh-CN/cluster.js
@@ -143,6 +143,7 @@ export default {
   "cluster.metrics.axis.node_health.title": "健康状态百分比",
   "cluster.metrics.axis.parent_breaker.title": "Circuit Breaker",
   "cluster.metrics.axis.circuit_breaker.title": "Circuit Breaker",
+  "cluster.metrics.axis.segment_memory.title": "Segment",
 
   "cluster.metrics.node.axis.cpu.title": "进程 CPU 使用率",
   "cluster.metrics.node.axis.disk.title": "磁盘可用率",
@@ -246,6 +247,10 @@ export default {
   "cluster.metrics.index.axis.segment_term_vectors_memory.title":
     "Term Vectors",
   "cluster.metrics.index.axis.segment_index_writer_memory.title": "IndexWriter",
+  "cluster.metrics.index.axis.segment_norms_memory.title": "Segment Norms Memory",
+  "cluster.metrics.index.axis.segment_points_memory.title": "Segment Points Memory",
+  "cluster.metrics.index.axis.segment_version_map.title": "Segment Version Map",
+  "cluster.metrics.index.axis.segment_fixed_bit_set.title": "Segment Fixed Bit Set",
   "cluster.metrics.group.system": "系统指标",
   "cluster.metrics.group.storage": "存储分析",
   "cluster.metrics.group.latency": "延迟分析",

--- a/web/src/pages/Platform/Overview/Cluster/Monitor/advanced.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Monitor/advanced.jsx
@@ -290,7 +290,11 @@ export default (props) => {
                     "segment_memory",
                     "segment_terms_memory",
                     "segment_index_writer_memory",
-                    "segment_term_vectors_memory"
+                    "segment_term_vectors_memory",
+                    "segment_norms_memory",
+                    "segment_points_memory",
+                    "segment_version_map",
+                    "segment_fixed_bit_set",
                 ]
             ],
             [

--- a/web/src/pages/Platform/Overview/Indices/Monitor/advanced.jsx
+++ b/web/src/pages/Platform/Overview/Indices/Monitor/advanced.jsx
@@ -64,7 +64,11 @@ export default (props) => {
                 "segment_memory",
                 "segment_terms_memory",
                 "segment_index_writer_memory",
-                "segment_term_vectors_memory"
+                "segment_term_vectors_memory",
+                "segment_norms_memory",
+                "segment_points_memory",
+                "segment_version_map",
+                "segment_fixed_bit_set",
             ]
         ],
         [

--- a/web/src/pages/Platform/Overview/Indices/Monitor/overview.jsx
+++ b/web/src/pages/Platform/Overview/Indices/Monitor/overview.jsx
@@ -26,7 +26,7 @@ export default (props) => {
         "search_throughput",
         "index_latency",
         "search_latency",
-        isAgent && !shardID ? "shard_state" : undefined,
+        isAgent ? (shardID ? undefined : "shard_state") : "segment_memory",
       ].filter((item) => !!item)}
     />
   );


### PR DESCRIPTION
## What does this PR do
1. add some metrics to index's monitor
- segment_norms_memory
- segment_points_memory
- segment_version_map
- segment_fixed_bit_set

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation