### PR TITLE
chore: commmit message check

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -12,9 +12,8 @@ jobs:
         with:
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
-          excludeTitle: 'true' # optional: this excludes the title of a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^(change:|feat:|improve:|perf:|dep:|docs:|test:|ci:|style:|refactor:|fix:|fixdoc:|fixup:|merge|Merge|bumpver:|chore:|build:) .+$'
+          pattern: '^(change:|feat:|improve:|perf:|dep:|docs:|test:|ci:|style:|refactor:|fix:|fixdoc:|fixup:|merge|Merge|update|Update|bumpver:|chore:|build:) .+$'
           flags: 'gm'
           error: |
             Subject line has to contain a commit type, e.g.: "chore: blabla" or a merge commit e.g.: "merge xxx".


### PR DESCRIPTION
## What does this PR do
commmit message check
## Rationale for this change
This pull request includes a modification to the commit message check workflow configuration in the `.github/workflows/commit-message-check.yml` file. The most important change is the update to the commit message pattern to include additional types.

Changes to commit message check workflow:

* [`.github/workflows/commit-message-check.yml`](diffhunk://#diff-73e8619abf322bb25f592ba9554da3f8d577c5f9031cca8909560c3413d81a29L15-R16): Updated the `pattern` to include `update` and `Update` as valid commit types.
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation