### PR TITLE
chore: add format check for unformatted Go files in CI pipeline

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -126,7 +126,17 @@ jobs:
           
           - name: Fail workflow if changes after format
             if: steps.check-changes.outputs.changes == 'true'
-            run: exit 1
+            run: |
+                export WORKBASE=$HOME/go/src/infini.sh
+                export WORK=$WORKBASE/$PNAME
+
+                # for foramt check
+                cd $WORK && echo
+                git status --porcelain | grep " M .*\.go$"
+                echo "----------------------------------------------------------------------------------"
+                echo "IMPORTANT: Above files are not formatted, please run 'make format' to format them."
+                echo "----------------------------------------------------------------------------------"
+                exit 1
 
     unit_test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do
typo imformat output
## Rationale for this change
This pull request includes an update to the `.github/workflows/pr_check.yml` file to improve the workflow when changes are detected after formatting. The most important change is the enhancement of the failure message to provide more detailed instructions to the user.

Enhancements to workflow failure message:

* [`.github/workflows/pr_check.yml`](diffhunk://#diff-420f4a16d0bf9d7626fa0fa302aee0382b72f5fdbf9e55cfcad43a4bbd6dfb9dL129-R139): Enhanced the failure message to include a detailed explanation and instructions when changes are detected after formatting. This includes setting environment variables, navigating to the workspace, checking the status of `.go` files, and prompting the user to run 'make format'.
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation