### PR TITLE
chore: restore generated file

### DIFF
--- a/config/generated.go
+++ b/config/generated.go
@@ -1,0 +1,11 @@
+package config
+
+const LastCommitLog = "N/A"
+
+const BuildDate = "N/A"
+
+const EOLDate = "N/A"
+
+const Version = "0.0.1-SNAPSHOT"
+
+const BuildNumber = "001"


### PR DESCRIPTION
## What does this PR do
restore generated file
## Rationale for this change
This pull request includes the addition of several constants to the `config/generated.go` file. These constants are used to store metadata about the build, such as the last commit log, build date, end-of-life date, version, and build number.

The most important changes include:

* [`config/generated.go`](diffhunk://#diff-04ad8280d4f2ce9ef80df56c1721bb3627ca651352aea7132d7c35cc01adfaf0R1-R11): Added constants `LastCommitLog`, `BuildDate`, `EOLDate`, `Version`, and `BuildNumber` to store build metadata.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation