### PR TITLE
fix: the invalid ip

### DIFF
--- a/modules/agent/api/elasticsearch.go
+++ b/modules/agent/api/elasticsearch.go
@@ -31,6 +31,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"runtime"
+	"sync/atomic"
+	"time"
+
 	"github.com/buger/jsonparser"
 	log "github.com/cihub/seelog"
 	"infini.sh/console/plugin/managed/server"
@@ -43,10 +48,6 @@ import (
 	"infini.sh/framework/modules/elastic/adapter"
 	"infini.sh/framework/modules/elastic/common"
 	"infini.sh/framework/modules/elastic/metadata"
-	"net/http"
-	"runtime"
-	"sync/atomic"
-	"time"
 )
 
 // node -> binding item
@@ -603,6 +604,11 @@ func (h *APIHandler) bindInstanceToCluster(clusterInfo ClusterInfo, nodes *elast
 							if util.ContainStr(ip, "::") {
 								ip = fmt.Sprintf("[%s]", ip)
 							}
+
+							if util.ContainStr(ip, "*") {
+								ip = "127.0.0.1"
+							}
+
 							nodeHost := fmt.Sprintf("%s:%d", ip, port)
 							nodeInfo := h.internalProcessBind(clusterID, clusterUUID, instanceID, instanceEndpoint, pid, nodeHost, auth)
 							if nodeInfo != nil {

--- a/modules/agent/api/elasticsearch.go
+++ b/modules/agent/api/elasticsearch.go
@@ -606,7 +606,7 @@ func (h *APIHandler) bindInstanceToCluster(clusterInfo ClusterInfo, nodes *elast
 							}
 
 							if util.ContainStr(ip, "*") {
-								ip = "127.0.0.1"
+								ip = util.LocalAddress
 							}
 
 							nodeHost := fmt.Sprintf("%s:%d", ip, port)


### PR DESCRIPTION
## What does this PR do
This pull request includes several changes to the `modules/agent/api/elasticsearch.go` file, primarily focusing on the import statements and the `bindInstanceToCluster` function.

### Import statement changes:

* Reorganized the import statements by moving `net/http`, `runtime`, `sync/atomic`, and `time` to the top section.
* Removed the same imports from the lower section to avoid redundancy.

### Function modification:

* Updated the `bindInstanceToCluster` function to handle IP addresses containing an asterisk ('*') by replacing them with `127.0.0.1`.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation