### PR TITLE
feat: rollup init template update

### DIFF
--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -1,22 +1,5 @@
-PUT /.easysearch-ilm-config/_settings
-{
-  "index": {
-    "mapping": {
-      "nested_fields": {
-        "limit": 1000
-      },
-      "nested_objects": {
-        "limit": 20000
-      },
-      "total_fields": {
-        "limit": 30000
-      }
-    }
-  }
-}
-
-DELETE _rollup/jobs/rollup_index_stats
-PUT _rollup/jobs/rollup_index_stats?replace
+DELETE /_rollup/jobs/rollup_index_stats
+PUT /_rollup/jobs/rollup_index_stats
 {
   "rollup": {
     "source_index": ".infini_metrics",
@@ -29,6 +12,9 @@ PUT _rollup/jobs/rollup_index_stats?replace
     "stats": [
           {
             "max": {}
+          },
+          {
+            "min": {}
           },
           {
             "value_count": {}
@@ -56,8 +42,8 @@ PUT _rollup/jobs/rollup_index_stats?replace
   }
 }
 
-DELETE _rollup/jobs/rollup_index_health
-PUT _rollup/jobs/rollup_index_health?replace
+DELETE /_rollup/jobs/rollup_index_health
+PUT /_rollup/jobs/rollup_index_health
 {
   "rollup": {
     "source_index": ".infini_metrics",
@@ -96,8 +82,8 @@ PUT _rollup/jobs/rollup_index_health?replace
   }
 }
 
-DELETE _rollup/jobs/rollup_cluster_stats
-PUT _rollup/jobs/rollup_cluster_stats?replace
+DELETE /_rollup/jobs/rollup_cluster_stats
+PUT /_rollup/jobs/rollup_cluster_stats
 {
   "rollup": {
     "source_index": ".infini_metrics",
@@ -136,8 +122,8 @@ PUT _rollup/jobs/rollup_cluster_stats?replace
   }
 }
 
-DELETE _rollup/jobs/rollup_cluster_health
-PUT _rollup/jobs/rollup_cluster_health?replace
+DELETE /_rollup/jobs/rollup_cluster_health
+PUT /_rollup/jobs/rollup_cluster_health
 {
   "rollup": {
     "source_index": ".infini_metrics",
@@ -175,16 +161,15 @@ PUT _rollup/jobs/rollup_cluster_health?replace
   }
 }
 
-# 高级 节点
-DELETE _rollup/jobs/rollup_node_stats
-PUT _rollup/jobs/rollup_node_stats?replace
+DELETE /_rollup/jobs/rollup_node_stats
+PUT /_rollup/jobs/rollup_node_stats
 {
   "rollup": {
     "source_index": ".infini_metrics",
     "target_index": "rollup_node_stats_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 100,
+    "page_size": 200,
     "cron": "*/10 1-23 * * *",
     "timezone": "UTC",
     "stats": [
@@ -196,6 +181,42 @@ PUT _rollup/jobs/rollup_node_stats?replace
       },
       {
         "value_count": {}
+      }
+    ],
+    "special_metrics": [
+      {
+        "source_field": "payload.elasticsearch.node_stats.process.cpu.percent",
+        "metrics": [
+          {
+            "avg": {}
+          },
+          {
+            "max": {}
+          },
+          {
+            "min": {}
+          },
+          {
+            "percentiles": {}
+          }
+        ]
+      },
+      {
+        "source_field": "payload.elasticsearch.node_stats.jvm.mem.heap_used_in_bytes",
+        "metrics": [
+          {
+            "avg": {}
+          },
+          {
+            "max": {}
+          },
+          {
+            "min": {}
+          },
+          {
+            "percentiles": {}
+          }
+        ]
       }
     ],
     "interval": "1m",
@@ -222,20 +243,23 @@ PUT _rollup/jobs/rollup_node_stats?replace
   }
 }
 
-DELETE _rollup/jobs/rollup_shard_stats_metrics
-PUT _rollup/jobs/rollup_shard_stats_metrics?replace
+DELETE /_rollup/jobs/rollup_shard_stats_metrics
+PUT /_rollup/jobs/rollup_shard_stats_metrics
 {
   "rollup": {
     "source_index": ".infini_metrics",
     "target_index": "rollup_shard_stats_metrics_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 100,
+    "page_size": 200,
     "cron": "*/5 1-23 * * *",
     "timezone": "UTC",
     "stats": [
           {
             "max": {}
+          },
+          {
+            "min": {}
           },
           {
             "value_count": {}
@@ -265,8 +289,8 @@ PUT _rollup/jobs/rollup_shard_stats_metrics?replace
   }
 }
 
-DELETE _rollup/jobs/rollup_shard_stats_state
-PUT _rollup/jobs/rollup_shard_stats_state?replace
+DELETE /_rollup/jobs/rollup_shard_stats_state
+PUT /_rollup/jobs/rollup_shard_stats_state
 {
   "rollup": {
     "source_index": ".infini_metrics",
@@ -302,3 +326,36 @@ PUT _rollup/jobs/rollup_shard_stats_state?replace
     }
   }
 }
+
+# enable rollup search
+PUT /_cluster/settings
+{
+  "persistent": {
+    "rollup": {
+      "search": {
+        "enabled": "true"
+      }
+    }
+  }
+}
+
+# update index settings
+PUT /.easysearch-ilm-config/_settings
+{
+  "index": {
+    "mapping": {
+      "nested_fields": {
+        "limit": 1000
+      },
+      "nested_objects": {
+        "limit": 20000
+      },
+      "total_fields": {
+        "limit": 30000
+      }
+    }
+  }
+}
+
+# start all rollup jobs
+POST /_rollup/jobs/rollup*/_start

--- a/plugin/setup/setup.go
+++ b/plugin/setup/setup.go
@@ -708,7 +708,7 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 		elastic2.InitTemplate(true)
 	case "rollup":
 		if ver.Distribution == elastic.Easysearch {
-			if large, _ := util.VersionCompare(ver.Number, "1.9.2"); large > 0 {
+			if large, _ := util.VersionCompare(ver.Number, "1.10.0"); large > 0 {
 				useCommon = false
 				dslTplFileName = "template_rollup.tpl"
 			}


### PR DESCRIPTION
## What does this PR do
This pull request includes several changes to the `config/setup/easysearch/template_rollup.tpl` file to update Elasticsearch rollup jobs and settings, as well as a minor version check update in `plugin/setup/setup.go`. The most important changes include updating the endpoints for rollup jobs, adding new metrics and settings, and enabling rollup search.

### Updates to rollup jobs and settings:

* Updated endpoints for rollup jobs to include leading slashes (`DELETE /_rollup/jobs/rollup_index_stats`, `PUT /_rollup/jobs/rollup_index_stats`, etc.) [[1]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL1-R2) [[2]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL59-R46) [[3]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL99-R86) [[4]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL139-R126) [[5]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL178-R172) [[6]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL225-R263) [[7]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL268-R293).
* Added new metrics such as `min` and `special_metrics` for rollup jobs (`PUT _rollup/jobs/rollup_index_stats?replace`, `PUT _rollup/jobs/rollup_node_stats?replace`, `PUT _rollup/jobs/rollup_shard_stats_metrics?replace`) [[1]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bR16-R18) [[2]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bR186-R221) [[3]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL225-R263).
* Enabled rollup search and updated index settings (`PUT /_cluster/settings`, `PUT /.easysearch-ilm-config/_settings`).

### Codebase update:

* Updated version check in `plugin/setup/setup.go` to compare against version `1.10.0` instead of `1.9.2` for initializing rollup templates.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation