### PR TITLE
fix: correct cluster ID when retrieving TopN view

### DIFF
--- a/web/src/pages/Platform/Overview/components/TopN/index.jsx
+++ b/web/src/pages/Platform/Overview/components/TopN/index.jsx
@@ -63,7 +63,8 @@ export default (props) => {
     const fetchFields = async (clusterID, viewID, type, isAgent) => {
         if (!clusterID || !viewID) return;
         setLoading(true)
-        const res = await request(`/elasticsearch/${clusterID}/saved_objects/_bulk_get`, {
+        const systemClusterID = "infini_default_system_cluster";
+        const res = await request(`/elasticsearch/${systemClusterID}/saved_objects/_bulk_get`, {
             method: 'POST',
             body: [{ 
                 id: viewID,


### PR DESCRIPTION
## What does this PR do
correct cluster ID when retrieving TopN view
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation