### PR TITLE
chore: add rollup_hours_before

### DIFF
--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -334,7 +334,8 @@ PUT /_cluster/settings
     "rollup": {
       "search": {
         "enabled": "true"
-      }
+      },
+      "hours_before": "24"
     }
   }
 }


### PR DESCRIPTION
## What does this PR do
This pull request includes a change to the `config/setup/easysearch/template_rollup.tpl` file to enhance the rollup search settings.

* Added a new configuration parameter `"hours_before": "24"` to the rollup search settings in the `PUT /_cluster/settings` endpoint.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation