### PR TITLE
fix: must use term with rollup

### DIFF
--- a/config/setup/common/alerting.tpl
+++ b/config/setup/common/alerting.tpl
@@ -242,7 +242,7 @@ POST $[[SETUP_INDEX_PREFIX]]alert-rule/$[[SETUP_DOC_TYPE]]/builtin-cal8n7p7h710d
       "bool": {
         "must": [
           {
-            "match": {
+            "term": {
               "payload.elasticsearch.cluster_health.status": "red"
             }
           },
@@ -400,7 +400,7 @@ POST $[[SETUP_INDEX_PREFIX]]alert-rule/$[[SETUP_DOC_TYPE]]/builtin-calavvp7h710d
       ".infini_metrics"
     ],
     "filter": {},
-    "raw_filter": {"bool":{"must":[{"match":{"payload.elasticsearch.index_health.status":"red"}},{"term":{"metadata.name":{"value":"index_health"}}}]}},
+    "raw_filter": {"bool":{"must":[{"term":{"payload.elasticsearch.index_health.status":"red"}},{"term":{"metadata.name":{"value":"index_health"}}}]}},
     "time_field": "timestamp",
     "context": {
       "fields": null


### PR DESCRIPTION
## What does this PR do
This pull request includes changes to the alerting configuration templates to improve the accuracy of Elasticsearch health status checks. The main updates involve replacing the `match` query with the more precise `term` query.

Changes to alerting configuration:

* [`config/setup/common/alerting.tpl`](diffhunk://#diff-41e8c643cf392498b1d25251dde97bc06e7314ee424ac6710c12323155a4345fL245-R245): Replaced `match` with `term` for checking `payload.elasticsearch.cluster_health.status` to ensure more accurate status matching.
* [`config/setup/common/alerting.tpl`](diffhunk://#diff-41e8c643cf392498b1d25251dde97bc06e7314ee424ac6710c12323155a4345fL403-R403): Updated `raw_filter` to use `term` instead of `match` for `payload.elasticsearch.index_health.status` to improve the precision of index health status checks.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation