### PR TITLE
chore: update osv-scanner to 1.9.1

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.9.1"
     with:
       # Example of specifying custom arguments
       scan-args: |-

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -16,9 +16,11 @@ on:
     branches: [ "main" ]
 
 permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
-  # Read commit contents
+  # Only need to read contents
   contents: read
 
 jobs:


### PR DESCRIPTION
update osv-scanner to 1.9.1

## What does this PR do
This pull request includes an update to the `osv-scanner` workflow configuration to use a newer version of the reusable workflow.

* [`.github/workflows/osv-scanner.yml`](diffhunk://#diff-cffe33bb0ffb2810cb2ba28b35e9fb9ebef98fd615b71ef50305846fa8ba0e00L26-R26): Updated the `uses` directive to point to version `v1.9.1` of the `osv-scanner-reusable.yml` workflow.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation