### PR TITLE
chore: remove `strict_date_optional_time`

### DIFF
--- a/web/src/components/vendor/data/common/query/timefilter/get_time.ts
+++ b/web/src/components/vendor/data/common/query/timefilter/get_time.ts
@@ -72,7 +72,7 @@ function createTimeRangeFilter(
     {
       ...(bounds.min && { gte: bounds.min.toISOString() }),
       ...(bounds.max && { lte: bounds.max.toISOString() }),
-      format: 'strict_date_optional_time',
+      // format: 'strict_date_optional_time',
     },
     indexPattern
   );

--- a/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_histogram.ts
+++ b/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_histogram.ts
@@ -33,7 +33,7 @@ export const createFilterDateHistogram = (
     {
       gte: start.toISOString(),
       lt: start.add(interval).toISOString(),
-      format: 'strict_date_optional_time',
+      // format: 'strict_date_optional_time',
     },
     agg.getIndexPattern()
   );

--- a/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_range.ts
+++ b/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_range.ts
@@ -26,7 +26,7 @@ export const createFilterDateRange = (agg: IBucketAggConfig, { from, to }: DateR
   const filter: RangeFilterParams = {};
   if (from) filter.gte = moment(from).toISOString();
   if (to) filter.lt = moment(to).toISOString();
-  if (to && from) filter.format = 'strict_date_optional_time';
+  // if (to && from) filter.format = 'strict_date_optional_time';
 
   return buildRangeFilter(agg.params.field, filter, agg.getIndexPattern());
 };

--- a/web/src/components/vendor/data/public/actions/filters/create_filters_from_range_select.ts
+++ b/web/src/components/vendor/data/public/actions/filters/create_filters_from_range_select.ts
@@ -56,9 +56,9 @@ export async function createFiltersFromRangeSelectAction(event: RangeSelectConte
     lt: isDate ? moment(max).toISOString() : max,
   };
 
-  if (isDate) {
-    range.format = 'strict_date_optional_time';
-  }
+  // if (isDate) {
+  //   range.format = 'strict_date_optional_time';
+  // }
 
   return esFilters.mapAndFlattenFilters([esFilters.buildRangeFilter(field, range, indexPattern)]);
 }

--- a/web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx
+++ b/web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx
@@ -285,7 +285,7 @@ export default (props) => {
               [timeFieldName] : {
                 ...(bounds.min && { gte: bounds.min.toISOString() }),
                 ...(bounds.max && { lte: bounds.max.toISOString() }),
-                format: 'strict_date_optional_time',
+                // format: 'strict_date_optional_time',
               }
             }
           }


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation