### PR TITLE
fix: lose `Monitored` in cluster editing

### DIFF
--- a/web/src/pages/System/Cluster/Form.js
+++ b/web/src/pages/System/Cluster/Form.js
@@ -68,17 +68,7 @@ class ClusterForm extends React.Component {
   ];
 
   componentDidMount() {
-    //console.log(this.props.clusterConfig.editMode)
     const { match, dispatch, clusterConfig } = this.props;
-    if (clusterConfig?.editValue) {
-
-      this.setState({
-        monitored: clusterConfig?.editValue.hasOwnProperty("monitored")
-          ? clusterConfig?.editValue?.monitored
-          : false,
-      });
-    }
-
     dispatch({
       type: "clusterConfig/fetchCluster",
       payload: {
@@ -107,7 +97,8 @@ class ClusterForm extends React.Component {
         this.setState({
           needAuth,
           isManual,
-          collectMode
+          collectMode,
+          monitored: editValue?.hasOwnProperty("monitored") ? editValue?.monitored : false,
         });
       }
     });


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation