### PR TITLE
chore: add rollup ilm settings

### DIFF
--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -358,5 +358,42 @@ PUT /.easysearch-ilm-config/_settings
   }
 }
 
+# ilm settings for rollup indices
+DELETE _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
+PUT _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "min_age": "0ms",
+        "actions": {
+          "rollover": {
+            "max_age": "30d",
+            "max_size": "50gb"
+          },
+          "set_priority": {
+            "priority": 100
+          }
+        }
+      },
+      "delete": {
+        "min_age": "30d",
+        "actions": {
+          "delete": {
+            "timestamp_field": "timestamp.date_histogram",
+            "min_data_age": "30d"
+          }
+        }
+      }
+    }
+  }
+}
+
+# add ilm policy to rollup indices
+#POST _ilm/add/rollup_index_stats_logs-write
+#{
+#  "policy_id": "ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention"
+#}
+
 # start all rollup jobs
 POST /_rollup/jobs/rollup*/_start

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -13,6 +13,7 @@ Information about release notes of INFINI Console is provided here.
 
 ### Features
 - Support alerts based on bucket diff state (#119)
+- Add rollup ilm when use Easysearch (#128)
 
 ### Bug fix
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -13,6 +13,7 @@ title: "版本历史"
 
 ### Features
 - 告警功能支持根据桶之间文档数差值和内容差异告警 (#119)
+- 当使用 Easysearch 存储指标时，增加 Rollup 索引生命周期 (#128)
 ### Bug fix
 
 ### Improvements


### PR DESCRIPTION
## What does this PR do
This pull request introduces changes to the `config/setup/easysearch/template_rollup.tpl` file to implement ILM (Index Lifecycle Management) settings for rollup indices. The changes include defining a new ILM policy and associating it with rollup indices.

Key changes:

* Added a new ILM policy `ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention` that includes hot and delete phases with specific actions for rollover and deletion.
* Deleted any existing ILM policy with the same name before creating the new policy to ensure there are no conflicts.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation