### PR TITLE
chore: check easysearch version with rollup

### DIFF
--- a/plugin/setup/setup.go
+++ b/plugin/setup/setup.go
@@ -718,7 +718,7 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 		elastic2.InitTemplate(true)
 	case "rollup":
 		if ver.Distribution == elastic.Easysearch {
-			if large, _ := util.VersionCompare(ver.Number, "1.10.0"); large > 0 {
+			if large, _ := util.VersionCompare(ver.Number, "1.10.1"); large > 0 {
 				useCommon = false
 				dslTplFileName = "template_rollup.tpl"
 			}


### PR DESCRIPTION
## What does this PR do
This pull request includes a minor change to the `plugin/setup/setup.go` file. The change updates the version comparison for the `rollup` case to use version "1.10.1" instead of "1.10.0".

* [`plugin/setup/setup.go`](diffhunk://#diff-26689fdcb6d7636cb28559883b2ecd38f71765fc63383ca05d8e9f542e4ad6cbL721-R721): Updated version comparison in `initializeTemplate` function to use "1.10.1" instead of "1.10.0" for the `rollup` case.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation