### PR TITLE
chore: remove rollover which not support

### DIFF
--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -365,16 +365,7 @@ PUT _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
   "policy": {
     "phases": {
       "hot": {
-        "min_age": "0ms",
-        "actions": {
-          "rollover": {
-            "max_age": "30d",
-            "max_size": "50gb"
-          },
-          "set_priority": {
-            "priority": 100
-          }
-        }
+        "min_age": "0ms"
       },
       "delete": {
         "min_age": "30d",


### PR DESCRIPTION
## What does this PR do
This pull request includes a change to the index lifecycle management (ILM) policy in the `config/setup/easysearch/template_rollup.tpl` file. The primary change involves removing the rollover and set priority actions from the hot phase of the ILM policy.

Changes to ILM policy:

* [`config/setup/easysearch/template_rollup.tpl`](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL368-R368): Removed the `rollover` action with `max_age` of 30 days and `max_size` of 50GB, and the `set_priority` action with priority 100 from the hot phase of the ILM policy.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation