### PR TITLE
fix: incorrect cluster metric collection mode

### DIFF
--- a/modules/elastic/api/monitor_state.go
+++ b/modules/elastic/api/monitor_state.go
@@ -37,8 +37,11 @@ func GetMonitorState(clusterID string) string {
 	if conf == nil {
 		panic(fmt.Errorf("config of cluster [%s] is not found", clusterID))
 	}
-	if conf.MonitorConfigs != nil && !conf.MonitorConfigs.NodeStats.Enabled && !conf.MonitorConfigs.IndexStats.Enabled {
-		return elastic.ModeAgent
+	if conf.MetricCollectionMode == "" {
+		if conf.MonitorConfigs != nil && !conf.MonitorConfigs.NodeStats.Enabled && !conf.MonitorConfigs.IndexStats.Enabled {
+			return elastic.ModeAgent
+		}
+		return elastic.ModeAgentless
 	}
-	return elastic.ModeAgentless
+	return conf.MetricCollectionMode
 }


### PR DESCRIPTION
## What does this PR do
This pull request includes a change to the `GetMonitorState` function in the `modules/elastic/api/monitor_state.go` file. The change ensures that the `MetricCollectionMode` configuration is checked and returned if set, otherwise, the function falls back to the existing logic.

* [`modules/elastic/api/monitor_state.go`](diffhunk://#diff-970ffbfa2188eb977c7b309f055f66b319cc72ef942ffa80ecd0d712a877650cR40-R47): Added a check for `MetricCollectionMode` and return its value if it is set. This ensures that the function respects the `MetricCollectionMode` configuration.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation