### PR TITLE
fix: init user just one time

### DIFF
--- a/plugin/setup/setup.go
+++ b/plugin/setup/setup.go
@@ -506,6 +506,42 @@ func (module *Module) initialize(w http.ResponseWriter, r *http.Request, ps http
 
 	//保存默认集群
 	t := time.Now()
+	toSaveCfg.MetadataConfigs = &elastic.MetadataConfig{
+		HealthCheck: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+		ClusterSettingsCheck: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+		MetadataRefresh: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+		NodeAvailabilityCheck: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+	}
+	toSaveCfg.MonitorConfigs = &elastic.MonitorConfig{
+		ClusterStats: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+		NodeStats: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+		ClusterHealth: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+		IndexStats: elastic.TaskConfig{
+			Enabled:  true,
+			Interval: "10s",
+		},
+	}
 	toSaveCfg.Created = &t
 	err = orm.Save(nil, &toSaveCfg)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do
This pull request focuses on refactoring the setup process for the Easysearch ingest user in the `plugin/setup/setup.go` file. The changes aim to improve the code's organization and readability by consolidating the creation of the ingest user password and moving related logic to a more appropriate location.

Key changes include:

* Refactoring the ingest user password creation:
  * Moved the `ingestPassword` variable declaration to a higher scope, making it a package-level variable.
  * Removed the local `ingestPassword` variable creation from within the `initializeTemplate` function.

* Simplifying the `initializeTemplate` function:
  * Added logic to set the ingest user password and initialize the ingest user only when the `ver.Distribution` is `elastic.Easysearch`.
  * Removed redundant code for setting the ingest user password and initializing the ingest user.

* Improving parameter usage in the `initIngestUser` function:
  * Changed the `PutRole` and `PutUser` function calls to use the `username` parameter instead of the hardcoded `ingestUser` variable. [[1]](diffhunk://#diff-26689fdcb6d7636cb28559883b2ecd38f71765fc63383ca05d8e9f542e4ad6cbL928-R929) [[2]](diffhunk://#diff-26689fdcb6d7636cb28559883b2ecd38f71765fc63383ca05d8e9f542e4ad6cbL938-R939)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation