### PR TITLE
chore: update timeout settings

### DIFF
--- a/modules/agent/api/elasticsearch.go
+++ b/modules/agent/api/elasticsearch.go
@@ -108,7 +108,7 @@ func refreshNodesInfo(instanceID, instanceEndpoint string) (*elastic.DiscoveryRe
 		return nil, fmt.Errorf("error on get binding nodes info: %w", err)
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	nodesInfo, err := GetElasticsearchNodesViaAgent(ctxTimeout, instanceEndpoint)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do
This pull request includes an important change to the `modules/agent/api/elasticsearch.go` file. The change extends the timeout duration for the context used in the `refreshNodesInfo` function from 10 seconds to 30 seconds.

* [`modules/agent/api/elasticsearch.go`](diffhunk://#diff-4295f1bad933019be5f2d55253dd15c05937b5b45eedd03e2d6f7fc1ecc3a004L111-R111): Extended the timeout duration for the context in the `refreshNodesInfo` function from 10 seconds to 30 seconds to allow for more time when retrieving Elasticsearch nodes information.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation