### PR TITLE
chore: update default console.yml with default_roles

### DIFF
--- a/console.yml
+++ b/console.yml
@@ -104,6 +104,7 @@ security:
 #          group_attribute: "ou"
 #          bypass_api_key: true
 #          cache_ttl: "10s"
+#          default_roles: ["ReadonlyUI","DATA"] #default for all ldap users if no specify roles was defined
 #          role_mapping:
 #            group:
 #              superheros: [ "Administrator" ]
@@ -118,6 +119,7 @@ security:
 #          base_dn: "dc=example,dc=com"
 #          user_filter: "(uid=%s)"
 #          cache_ttl: "10s"
+#          default_roles: ["ReadonlyUI","DATA"] #default for all ldap users if no specify roles was defined
 #          role_mapping:
 #            uid:
 #              tesla: [ "readonly","data" ]


### PR DESCRIPTION
> ## What does this PR do
This pull request includes updates to the `console.yml` file to enhance the default role assignment for LDAP users.

Security configuration updates:

* [`console.yml`](diffhunk://#diff-a3691947d06f4e49bb69d806e8017995f714e058c199597764b8e2dd92437063R107): Added `default_roles` configuration to specify default roles for all LDAP users if no specific roles are defined. This change was made in two sections of the file. [[1]](diffhunk://#diff-a3691947d06f4e49bb69d806e8017995f714e058c199597764b8e2dd92437063R107) [[2]](diffhunk://#diff-a3691947d06f4e49bb69d806e8017995f714e058c199597764b8e2dd92437063R122)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation