### PR TITLE
chore: change sync with instance id

### DIFF
--- a/modules/agent/api/remote_config.go
+++ b/modules/agent/api/remote_config.go
@@ -53,18 +53,14 @@ func remoteConfigProvider(instance model.Instance) []*common.ConfigFile {
 
 	//fetch configs from remote db
 	//fetch configs assigned to (instance=_all OR instance=$instance_id ) AND application.name=$application.name
-	condition := orm.Eq("metadata.labels.instance", "_all")
-	if instance.Labels["instance"] != "" {
-		condition = orm.Eq("metadata.labels.instance", instance.Labels["instance"])
-	}
 	q := orm.Query{
 		Size: 1000,
 		Conds: orm.And(orm.Eq("metadata.category", "app_settings"),
 			orm.Eq("metadata.name", instance.Application.Name),
-			condition,
 		),
 	}
 
+	q.Conds = append(q.Conds, orm.Or(orm.Eq("metadata.labels.instance", "_all"), orm.Eq("metadata.labels.instance", instance.ID))...)
 	err, searchResult := orm.Search(RemoteConfig{}, &q)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## What does this PR do
This pull request includes a change to the `remoteConfigProvider` function in the `modules/agent/api/remote_config.go` file to improve the way configuration files are fetched from the remote database. The most important change is the modification of the query conditions used to fetch the configurations.

Improvements to query conditions:

* [`modules/agent/api/remote_config.go`](diffhunk://#diff-e6446c702fd7cfeaa357037efe7a6704c69650cc3a77a42ee74565fff24a9769L56-R63): The query conditions have been simplified by directly appending the `orm.Or` condition to include configurations assigned to either `_all` or the specific instance ID. This change replaces the previous approach of setting the condition based on the instance labels.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation