### PR TITLE
chore: rollback date format change

### DIFF
--- a/web/src/components/vendor/data/common/query/timefilter/get_time.ts
+++ b/web/src/components/vendor/data/common/query/timefilter/get_time.ts
@@ -72,7 +72,7 @@ function createTimeRangeFilter(
     {
       ...(bounds.min && { gte: bounds.min.toISOString() }),
       ...(bounds.max && { lte: bounds.max.toISOString() }),
-      // format: 'strict_date_optional_time',
+      format: 'strict_date_optional_time',
     },
     indexPattern
   );

--- a/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_histogram.ts
+++ b/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_histogram.ts
@@ -33,7 +33,7 @@ export const createFilterDateHistogram = (
     {
       gte: start.toISOString(),
       lt: start.add(interval).toISOString(),
-      // format: 'strict_date_optional_time',
+      format: 'strict_date_optional_time',
     },
     agg.getIndexPattern()
   );

--- a/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_range.ts
+++ b/web/src/components/vendor/data/common/search/aggs/buckets/create_filter/date_range.ts
@@ -26,7 +26,7 @@ export const createFilterDateRange = (agg: IBucketAggConfig, { from, to }: DateR
   const filter: RangeFilterParams = {};
   if (from) filter.gte = moment(from).toISOString();
   if (to) filter.lt = moment(to).toISOString();
-  // if (to && from) filter.format = 'strict_date_optional_time';
+  if (to && from) filter.format = 'strict_date_optional_time';
 
   return buildRangeFilter(agg.params.field, filter, agg.getIndexPattern());
 };

--- a/web/src/components/vendor/data/public/actions/filters/create_filters_from_range_select.ts
+++ b/web/src/components/vendor/data/public/actions/filters/create_filters_from_range_select.ts
@@ -56,9 +56,9 @@ export async function createFiltersFromRangeSelectAction(event: RangeSelectConte
     lt: isDate ? moment(max).toISOString() : max,
   };
 
-  // if (isDate) {
-  //   range.format = 'strict_date_optional_time';
-  // }
+  if (isDate) {
+    range.format = 'strict_date_optional_time';
+  }
 
   return esFilters.mapAndFlattenFilters([esFilters.buildRangeFilter(field, range, indexPattern)]);
 }

--- a/web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx
+++ b/web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx
@@ -295,9 +295,8 @@ export default (props) => {
           return {
             range: {
               [timeFieldName] : {
-                ...(bounds.min && { gte: bounds.min.toISOString() }),
-                ...(bounds.max && { lte: bounds.max.toISOString() }),
-                format: 'strict_date_optional_time',
+                ...(bounds.min && { gte: bounds.min.valueOf() }),
+                ...(bounds.max && { lte: bounds.max.valueOf() }),
               }
             }
           }

--- a/web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx
+++ b/web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx
@@ -297,7 +297,7 @@ export default (props) => {
               [timeFieldName] : {
                 ...(bounds.min && { gte: bounds.min.toISOString() }),
                 ...(bounds.max && { lte: bounds.max.toISOString() }),
-                // format: 'strict_date_optional_time',
+                format: 'strict_date_optional_time',
               }
             }
           }


### PR DESCRIPTION
## What does this PR do
This pull request includes a small change to the `web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx` file. The change re-enables the `format` field in the time bounds object by uncommenting the line.

* [`web/src/pages/DataManagement/View/Widget/WidgetBody/Chart.jsx`](diffhunk://#diff-d883c4a48e5bc59eca36f2f8c23191f2429a6be14c7339a67e61696b9016ad0aL300-R300): Uncommented the `format` field in the time bounds object to use 'strict_date_optional_time'.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation