### PR TITLE
docs: add miss release notes

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,8 +12,10 @@ Information about release notes of INFINI Console is provided here.
 ### Features  
 ### Bug fix  
 - Fixed long integer precision loss in DevTools (#182)
+- Rollback `strict_date_optional_time` change (#117) (#185)
 ### Improvements  
 - Optimize configs sync with labels(#176)
+- Optimize screen resolution adaptation for an improved user experience (#186)
 
 ## 1.29.1 (2025-03-14)
 ### Breaking changes  

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,9 +12,11 @@ title: "版本历史"
 ### Features  
 ### Bug fix  
 - 修复开发工具查询长整型数据精度丢失问题 (#182)
+- 回滚 `strict_date_optional_time` 修复 (#117) (#185)
 
 ### Improvements  
 - 优化配置同步时，可根据标签进行筛选(#176)
+- 优化屏幕分辨率适配，增强用户体验 (#186)
 
 ## 1.29.1 (2025-03-14)
 ### Breaking changes  


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the release notes for both English and Chinese documentation. The changes include bug fixes and improvements to user experience.

### Updates to release notes:

* [`docs/content.en/docs/release-notes/_index.md`](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5R15-R18): Added a rollback for `strict_date_optional_time` change and optimized screen resolution adaptation for an improved user experience.
* [`docs/content.zh/docs/release-notes/_index.md`](diffhunk://#diff-4ff3d025818365a9a33f0fbd7fd1853b95162421d6d7d8067fce7fb0e3f9349fR15-R19): Added a rollback for `strict_date_optional_time` fix and optimized screen resolution adaptation to enhance user experience.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation