### PR TITLE
fix: remove index cache when refresh data

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,6 +11,7 @@ Information about release notes of INFINI Console is provided here.
 ### Breaking changes  
 ### Features  
 ### Bug fix  
+- Fix index cache issue when recreating an index after deletion (#189)
 ### Improvements  
 
 ## 1.29.2 (2025-03-31)

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -10,7 +10,8 @@ title: "版本历史"
 ## Latest (In development)  
 ### Breaking changes  
 ### Features  
-### Bug fix  
+### Bug fix 
+- 修复删除索引后重建索引缓存问题 (#189)
 ### Improvements  
 
 ## 1.29.2 (2025-03-31)

--- a/web/src/pages/DataManagement/Index.js
+++ b/web/src/pages/DataManagement/Index.js
@@ -270,6 +270,8 @@ class Index extends PureComponent {
   }
 
   fetchData = () => {
+    this.props.index.mappings = {};
+    this.props.index.settings = {};
     const { dispatch, clusterID } = this.props;
     if (!clusterID) {
       return {};


### PR DESCRIPTION
## What does this PR do
Fix index cache issue when recreating an index after deletion
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation