### PR TITLE
chore: update rollup template with latest easysearch support

### DIFF
--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -6,8 +6,8 @@ PUT /_rollup/jobs/rollup_index_stats
     "target_index": "rollup_index_stats_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 100,
-    "cron": "*/10 1-23 * * *",
+    "page_size": 600,
+    "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
           {
@@ -38,7 +38,8 @@ PUT /_rollup/jobs/rollup_index_stats
     ],
     "filter": {
       "metadata.name": "index_stats"
-    }
+    },
+    "field_abbr": true
   }
 }
 
@@ -50,8 +51,8 @@ PUT /_rollup/jobs/rollup_index_health
     "target_index": "rollup_index_health_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 100,
-    "cron": "*/10 1-23 * * *",
+    "page_size": 600,
+    "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
           {
@@ -78,7 +79,8 @@ PUT /_rollup/jobs/rollup_index_health
     ],
     "filter": {
       "metadata.name": "index_health"
-    }
+    },
+    "field_abbr": true
   }
 }
 
@@ -88,9 +90,9 @@ PUT /_rollup/jobs/rollup_cluster_stats
   "rollup": {
     "source_index": ".infini_metrics",
     "target_index": "rollup_cluster_stats_{{ctx.source_index}}",
-    "page_size": 100,
+    "page_size": 600,
     "continuous": true,
-    "cron": "*/10 1-23 * * *",
+    "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
       {
@@ -118,7 +120,8 @@ PUT /_rollup/jobs/rollup_cluster_stats
     ],
     "filter": {
       "metadata.name": "cluster_stats"
-    }
+    },
+    "field_abbr": true
   }
 }
 
@@ -129,8 +132,8 @@ PUT /_rollup/jobs/rollup_cluster_health
     "source_index": ".infini_metrics",
     "target_index": "rollup_cluster_health_{{ctx.source_index}}",
     "continuous": true,
-    "page_size": 100,
-    "cron": "*/10 1-23 * * *",
+    "page_size": 600,
+    "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
       {
@@ -157,7 +160,8 @@ PUT /_rollup/jobs/rollup_cluster_health
     },
     "metrics": [
       "payload.elasticsearch.cluster_health.*"
-    ]
+    ],
+    "field_abbr": true
   }
 }
 
@@ -169,8 +173,8 @@ PUT /_rollup/jobs/rollup_node_stats
     "target_index": "rollup_node_stats_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 200,
-    "cron": "*/10 1-23 * * *",
+    "page_size": 600,
+    "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
       {
@@ -239,7 +243,8 @@ PUT /_rollup/jobs/rollup_node_stats
     ],
     "metrics": [
       "payload.elasticsearch.node_stats.*"
-    ]
+    ],
+    "field_abbr": true
   }
 }
 
@@ -251,8 +256,8 @@ PUT /_rollup/jobs/rollup_shard_stats_metrics
     "target_index": "rollup_shard_stats_metrics_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 200,
-    "cron": "*/5 1-23 * * *",
+    "page_size": 600,
+    "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
           {
@@ -284,8 +289,8 @@ PUT /_rollup/jobs/rollup_shard_stats_metrics
     "filter": {
       "metadata.name": "shard_stats",
       "payload.elasticsearch.shard_stats.routing.primary": true
-
-    }
+    },
+    "field_abbr": true
   }
 }
 
@@ -297,8 +302,8 @@ PUT /_rollup/jobs/rollup_shard_stats_state
     "target_index": "rollup_shard_stats_state_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 100,
-    "cron": "*/5 1-23 * * *",
+    "page_size": 600,
+    "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
           {
@@ -323,7 +328,8 @@ PUT /_rollup/jobs/rollup_shard_stats_state
     ],
     "filter": {
       "metadata.name": "shard_stats"
-    }
+    },
+    "field_abbr": true
   }
 }
 
@@ -349,7 +355,7 @@ PUT /.easysearch-ilm-config/_settings
         "limit": 1000
       },
       "nested_objects": {
-        "limit": 20000
+        "limit": 60000
       },
       "total_fields": {
         "limit": 30000
@@ -359,8 +365,8 @@ PUT /.easysearch-ilm-config/_settings
 }
 
 # ilm settings for rollup indices
-DELETE _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
-PUT _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
+DELETE _ilm/policy/ilm_.infini_rollup-30days-retention
+PUT _ilm/policy/ilm_.infini_rollup-30days-retention
 {
   "policy": {
     "phases": {
@@ -387,7 +393,7 @@ PUT _template/rollup_policy_template
   "order": 1, 
   "index_patterns": ["rollup*"],
   "settings": {
-    "index.lifecycle.name": "ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention"
+    "index.lifecycle.name": "ilm_.infini_rollup-30days-retention"
   }
 }
 

--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -366,7 +366,7 @@ PUT /.easysearch-ilm-config/_settings
 
 # ilm settings for rollup indices
 DELETE _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
-PUT _ilm/policy/ilm_[[SETUP_INDEX_PREFIX]]rollup-30days-retention
+PUT _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
 {
   "policy": {
     "phases": {

--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -2,7 +2,7 @@ DELETE /_rollup/jobs/rollup_index_stats
 PUT /_rollup/jobs/rollup_index_stats
 {
   "rollup": {
-    "source_index": ".infini_metrics",
+    "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_index_stats_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
@@ -47,7 +47,7 @@ DELETE /_rollup/jobs/rollup_index_health
 PUT /_rollup/jobs/rollup_index_health
 {
   "rollup": {
-    "source_index": ".infini_metrics",
+    "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_index_health_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
@@ -88,7 +88,7 @@ DELETE /_rollup/jobs/rollup_cluster_stats
 PUT /_rollup/jobs/rollup_cluster_stats
 {
   "rollup": {
-    "source_index": ".infini_metrics",
+    "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_cluster_stats_{{ctx.source_index}}",
     "page_size": 600,
     "continuous": true,
@@ -129,7 +129,7 @@ DELETE /_rollup/jobs/rollup_cluster_health
 PUT /_rollup/jobs/rollup_cluster_health
 {
   "rollup": {
-    "source_index": ".infini_metrics",
+    "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_cluster_health_{{ctx.source_index}}",
     "continuous": true,
     "page_size": 600,
@@ -169,7 +169,7 @@ DELETE /_rollup/jobs/rollup_node_stats
 PUT /_rollup/jobs/rollup_node_stats
 {
   "rollup": {
-    "source_index": ".infini_metrics",
+    "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_node_stats_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
@@ -252,7 +252,7 @@ DELETE /_rollup/jobs/rollup_shard_stats_metrics
 PUT /_rollup/jobs/rollup_shard_stats_metrics
 {
   "rollup": {
-    "source_index": ".infini_metrics",
+    "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_shard_stats_metrics_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
@@ -298,7 +298,7 @@ DELETE /_rollup/jobs/rollup_shard_stats_state
 PUT /_rollup/jobs/rollup_shard_stats_state
 {
   "rollup": {
-    "source_index": ".infini_metrics",
+    "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_shard_stats_state_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
@@ -365,8 +365,8 @@ PUT /.easysearch-ilm-config/_settings
 }
 
 # ilm settings for rollup indices
-DELETE _ilm/policy/ilm_.infini_rollup-30days-retention
-PUT _ilm/policy/ilm_.infini_rollup-30days-retention
+DELETE _ilm/policy/ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention
+PUT _ilm/policy/ilm_[[SETUP_INDEX_PREFIX]]rollup-30days-retention
 {
   "policy": {
     "phases": {
@@ -393,7 +393,7 @@ PUT _template/rollup_policy_template
   "order": 1, 
   "index_patterns": ["rollup*"],
   "settings": {
-    "index.lifecycle.name": "ilm_.infini_rollup-30days-retention"
+    "index.lifecycle.name": "ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention"
   }
 }
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,7 +12,7 @@ Information about release notes of INFINI Console is provided here.
 ### 🚀 Features  
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
-- chore: update rollup template with latest easysearch support (#199)
+- chore: update rollup template with latest Easysearch support (#199)
 
 ## 1.29.3 (2025-04-27)
 ### Breaking changes  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of INFINI Console is provided here.
 ### 🚀 Features  
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- chore: update rollup template with latest easysearch support (#199)
 
 ## 1.29.3 (2025-04-27)
 ### Breaking changes  

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,7 +12,7 @@ title: "版本历史"
 ### 🚀 Features  
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
-- chore: 将 Rollup 模板更新为最新的 EasySearch 支持版本 (#199)
+- chore: 将 Rollup 模板更新为最新的 Easysearch 支持版本 (#199)
 
 ## 1.29.3 (2025-04-27)
 ### Breaking changes  

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ title: "版本历史"
 ### 🚀 Features  
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- chore: 将 Rollup 模板更新为最新的 EasySearch 支持版本 (#199)
 
 ## 1.29.3 (2025-04-27)
 ### Breaking changes  


### PR DESCRIPTION
## What does this PR do
This pull request updates rollup job configurations and index settings in the `config/setup/easysearch/template_rollup.tpl` file. The changes primarily focus on increasing performance and adding new configuration options for rollup jobs, as well as updating lifecycle management policies.

### Rollup Job Configuration Updates:
* Increased `page_size` from 100/200 to 600 across all rollup jobs to improve batch processing efficiency. (`[[1]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL9-R10)`, `[[2]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL53-R55)`, `[[3]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL91-R95)`, `[[4]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL132-R136)`, `[[5]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL172-R177)`, `[[6]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL254-R260)`, `[[7]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL300-R306)`)
* Adjusted `cron` schedules to run every 5 minutes across all hours (`0-23`), instead of every 10 minutes or limited hours (`1-23`). (`[[1]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL9-R10)`, `[[2]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL53-R55)`, `[[3]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL91-R95)`, `[[4]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL132-R136)`, `[[5]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL172-R177)`, `[[6]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL254-R260)`, `[[7]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL300-R306)`)
* Added a new `field_abbr` option to enable field abbreviation in rollup job configurations. (`[[1]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL41-R42)`, `[[2]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL81-R83)`, `[[3]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL121-R124)`, `[[4]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL160-R164)`, `[[5]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL242-R247)`, `[[6]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL287-R293)`, `[[7]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL326-R332)`)

### Index Settings Updates:
* Increased `nested_objects.limit` from 20,000 to 60,000 to support more nested objects in `.easysearch-ilm-config`. (`[config/setup/easysearch/template_rollup.tplL352-R358](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL352-R358)`)

### Lifecycle Management Policy Updates:
* Updated ILM policy names to use the `.infini_rollup-30days-retention` prefix instead of `$[[SETUP_INDEX_PREFIX]]`. (`[[1]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL362-R369)`, `[[2]](diffhunk://#diff-41898fd9199072918941b5df6ca935e50190839f2087909723de4380b291033bL390-R396)`)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation