### PR TITLE
feat: support custom TLS minimum version for SMTP server configuration

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,6 +10,7 @@ Information about release notes of INFINI Console is provided here.
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- Support custom TLS minimum version for SMTP server configuration
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -10,6 +10,7 @@ title: "版本历史"
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- 支持配置邮件服务器最小 TLS 使用版本
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 

--- a/model/email_server.go
+++ b/model/email_server.go
@@ -28,20 +28,45 @@
 package model
 
 import (
+	"crypto/tls"
 	"fmt"
+
 	"infini.sh/framework/core/model"
 	"infini.sh/framework/core/orm"
 )
 
 type EmailServer struct {
 	orm.ORMObjectBase
-	Name         string           `json:"name" elastic_mapping:"name:{type:text}"`
-	Host         string           `json:"host" elastic_mapping:"host:{type:keyword}"`
-	Port         int              `json:"port" elastic_mapping:"port:{type:keyword}"`
-	TLS          bool             `json:"tls" elastic_mapping:"tls:{type:keyword}"`
-	Auth         *model.BasicAuth `json:"auth" elastic_mapping:"auth:{type:object}"`
-	Enabled      bool             `json:"enabled" elastic_mapping:"enabled:{type:boolean}"`
-	CredentialID string           `json:"credential_id" elastic_mapping:"credential_id:{type:keyword}"`
+	Name          string           `json:"name" elastic_mapping:"name:{type:text}"`
+	Host          string           `json:"host" elastic_mapping:"host:{type:keyword}"`
+	Port          int              `json:"port" elastic_mapping:"port:{type:keyword}"`
+	TLS           bool             `json:"tls" elastic_mapping:"tls:{type:keyword}"`
+	Auth          *model.BasicAuth `json:"auth" elastic_mapping:"auth:{type:object}"`
+	Enabled       bool             `json:"enabled" elastic_mapping:"enabled:{type:boolean}"`
+	CredentialID  string           `json:"credential_id" elastic_mapping:"credential_id:{type:keyword}"`
+	TLSMinVersion string           `json:"tls_min_version" elastic_mapping:"tls_min_version:{type:keyword}"`
+}
+
+const (
+	TLSVersion10 = "TLS10"
+	TLSVersion11 = "TLS11"
+	TLSVersion12 = "TLS12"
+	TLSVersion13 = "TLS13"
+)
+
+func GetTLSVersion(version string) (uint16, error) {
+	switch version {
+	case TLSVersion10:
+		return tls.VersionTLS10, nil
+	case TLSVersion11:
+		return tls.VersionTLS11, nil
+	case TLSVersion12:
+		return tls.VersionTLS12, nil
+	case TLSVersion13:
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version [%s]", version)
+	}
 }
 
 func (serv *EmailServer) Validate(requireName bool) error {

--- a/plugin/api/email/common/pipeline.go
+++ b/plugin/api/email/common/pipeline.go
@@ -29,15 +29,16 @@ package common
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"time"
+
 	"gopkg.in/yaml.v2"
 	"infini.sh/console/model"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/keystore"
 	"infini.sh/framework/core/orm"
 	"infini.sh/framework/core/util"
-	"os"
-	"path"
-	"time"
 )
 
 const emailServerConfigFile = "send_email.yml"
@@ -117,6 +118,7 @@ func GeneratePipelineConfig(servers []model.EmailServer) (string, error) {
 				"tls":               srv.TLS,
 				"refresh_timestamp": time.Now().UnixMilli(),
 			},
+			"min_tls_version": srv.TLSMinVersion,
 			"auth": util.MapStr{
 				"username": srv.Auth.Username,
 				"password": fmt.Sprintf("$[[keystore.%s]]", key),

--- a/web/src/pages/System/Email/Components/ServerConfig.jsx
+++ b/web/src/pages/System/Email/Components/ServerConfig.jsx
@@ -142,6 +142,18 @@ export default Form.create({ name: "email_server_cfg" })((props) => {
             ],
           })(<InputNumber />)}
         </Form.Item>
+        <Form.Item label="TLS Min Version">
+          {getFieldDecorator("tls_min_version", {
+            initialValue: config.tls_min_version,
+            rules: [
+            ],
+          })(<Select>
+            <Option value="TLS10">TLS10</Option>
+            <Option value="TLS11">TLS11</Option>
+            <Option value="TLS12">TLS12</Option>
+            <Option value="TLS13">TLS13</Option>
+          </Select>)}
+        </Form.Item>
         <Form.Item label="TLS">
           {getFieldDecorator("tls", {
             initialValue: config.tls,


### PR DESCRIPTION
## What does this PR do
support custom TLS minimum version for SMTP server configuration
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation