### PR TITLE
fix: rollup error when change select cluster without return

### DIFF
--- a/web/src/pages/Platform/Overview/Cluster/Monitor/index.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Monitor/index.jsx
@@ -47,55 +47,55 @@ const Page = (props) => {
   if (clusterStatus && selectedCluster && clusterStatus[selectedCluster.id]) {
     clusterAvailable = clusterStatus[selectedCluster.id].available;
     clusterMonitored = clusterStatus[selectedCluster.id].config.monitored;
+  }
+  const panes = getPanes(clusterID);
 
-    const panes = getPanes(clusterID);
-    return (
-      <Monitor
-        selectedCluster={selectedCluster}
-        formatState={(state) => {
-          let clusterID = props.match.params?.cluster_id;
-          if (
-            props.selectedCluster?.id &&
-            props.selectedCluster?.id !== clusterID
-          ) {
-            clusterID = props.selectedCluster?.id;
-          }
-          return {
-            ...state,
-            clusterID: clusterID || "",
-          };
-        }}
-        getBreadcrumbList={() => [
-          {
-            title: formatMessage({ id: "menu.home" }),
-            href: "/",
-          },
-          {
-            title: formatMessage({ id: "menu.cluster" }),
-          },
-          {
-            title: formatMessage({ id: "menu.cluster.monitoring" }),
-          },
-          {
-            title: selectedCluster?.name || "",
-          },
-        ]}
-        StatisticBar={StatisticBar}
-        extraParams={{
-          clusterAvailable,
-          clusterMonitored,
-          clusterName: selectedCluster?.name,
-          clusterID:
-            props.selectedCluster?.id &&
-            props.selectedCluster?.id !== props.match.params?.cluster_id
-              ? props.selectedCluster?.id
-              : props.match.params?.cluster_id,
-        }}
-        panes={panes}
-        checkPaneParams={(params) => !!params.clusterID}
-      />
-    );
-  };
+  return (
+    <Monitor
+      selectedCluster={selectedCluster}
+      formatState={(state) => {
+        let clusterID = props.match.params?.cluster_id;
+        if (
+          props.selectedCluster?.id &&
+          props.selectedCluster?.id !== clusterID
+        ) {
+          clusterID = props.selectedCluster?.id;
+        }
+        return {
+          ...state,
+          clusterID: clusterID || "",
+        };
+      }}
+      getBreadcrumbList={() => [
+        {
+          title: formatMessage({ id: "menu.home" }),
+          href: "/",
+        },
+        {
+          title: formatMessage({ id: "menu.cluster" }),
+        },
+        {
+          title: formatMessage({ id: "menu.cluster.monitoring" }),
+        },
+        {
+          title: selectedCluster?.name || "",
+        },
+      ]}
+      StatisticBar={StatisticBar}
+      extraParams={{
+        clusterAvailable,
+        clusterMonitored,
+        clusterName: selectedCluster?.name,
+        clusterID:
+          props.selectedCluster?.id &&
+          props.selectedCluster?.id !== props.match.params?.cluster_id
+            ? props.selectedCluster?.id
+            : props.match.params?.cluster_id,
+      }}
+      panes={panes}
+      checkPaneParams={(params) => !!params.clusterID}
+    />
+  );
 };
 
 export default connect(({ global }) => ({


### PR DESCRIPTION
## What does this PR do
This pull request makes minor adjustments to the `Page` component in the `Monitor` page to fix a logical issue and clean up the code. The changes ensure proper handling of the `clusterStatus` logic and remove an unnecessary closing brace.

Code fixes and cleanup:

* [`web/src/pages/Platform/Overview/Cluster/Monitor/index.jsx`](diffhunk://#diff-02cb7e98d0a1a8a0b10dc61c9d014d0ff66eae5316b47a0841c6a015c479dc0fL50-R52): Added a missing closing brace to properly encapsulate the `if` block for `clusterStatus` and `selectedCluster` checks.
* [`web/src/pages/Platform/Overview/Cluster/Monitor/index.jsx`](diffhunk://#diff-02cb7e98d0a1a8a0b10dc61c9d014d0ff66eae5316b47a0841c6a015c479dc0fL99): Removed an extra closing brace that was incorrectly placed after the `Page` component definition.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation