### PR TITLE
chore: do not show rollup metrics if rollup is disabled

### DIFF
--- a/web/src/components/Overview/Monitor/index.jsx
+++ b/web/src/components/Overview/Monitor/index.jsx
@@ -16,6 +16,7 @@ import CollectStatus from "@/components/CollectStatus";
 import RollupStats from "@/components/RollupStats";
 import styles from "./index.less"
 import { isSystemCluster } from "@/utils/setup";
+import { getRollupEnabled } from "@/utils/authority";
 
 const { TabPane } = Tabs;
 
@@ -230,7 +231,7 @@ const Monitor = (props) => {
                     />
                   </div>
                   <div style={{display: "flex"}}>
-                    {isSystemCluster(selectedCluster?.id) && <RollupStats
+                    {isSystemCluster(selectedCluster?.id) && getRollupEnabled() === "true" && <RollupStats
                       fetchUrl={`${ESPrefix}/${selectedCluster?.id}/_proxy?method=GET&path=/_rollup/jobs/*/_explain`}
                       style={{ marginRight: 100 }}/>}
                     <CollectStatus filter={collectionStatsFilter} fetchUrl={`${ESPrefix}/${selectedCluster?.id}/_collection_stats`}/>

--- a/web/src/components/RollupStats/index.js
+++ b/web/src/components/RollupStats/index.js
@@ -52,7 +52,7 @@ export default (props) => {
         if (showLoading) {
             setLoading(true)
         }
-        const res = await request(fetchUrl, {method: 'POST'});
+        const res = await request(fetchUrl, {method: 'POST'}, false, false);
         if (res && !res?.error) {
           const body = res?.response_body || '';
           let retObj = {};

--- a/web/src/pages/Platform/Overview/Cluster/Monitor/index.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Monitor/index.jsx
@@ -12,6 +12,7 @@ import TopN from "./TopN";
 import Logs from "./Logs";
 import Rollup from "./Rollup";
 import { isSystemCluster } from "@/utils/setup";
+import { getRollupEnabled } from "@/utils/authority";
 
 const getPanes = (clusterID) => {
   const basePanes = [
@@ -23,7 +24,7 @@ const getPanes = (clusterID) => {
     { title: "Indices", component: Indices, key: "indices" },
   ];
 
-  if (isSystemCluster(clusterID)) {
+  if (isSystemCluster(clusterID) && getRollupEnabled() === "true") {
     const overviewIndex = basePanes.findIndex(p => p.key === "overview");
     basePanes.splice(overviewIndex + 1, 0, {
       title: "Rollup",


### PR DESCRIPTION
## What does this PR do
do not show rollup metrics if rollup is disabled
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation