### PR TITLE
chore: discover show data chart default

### DIFF
--- a/web/src/pages/DataManagement/Discover.jsx
+++ b/web/src/pages/DataManagement/Discover.jsx
@@ -179,7 +179,7 @@ const Discover = (props) => {
     enabled: false,
   };
 
-  const [histogramVisible, setHistogramVisible] = useState(false)
+  const [histogramVisible, setHistogramVisible] = useState(true)
 
   const [distinctParams, setDistinctParams] = React.useState(
     distinctParamsDefault


### PR DESCRIPTION
## What does this PR do
This pull request includes a small change to the `Discover` component in `web/src/pages/DataManagement/Discover.jsx`. The default state of `histogramVisible` has been updated to `true` instead of `false` to ensure histograms are visible by default.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation