### PR TITLE
chore: only use partition for top index name search

### DIFF
--- a/modules/elastic/api/cluster_overview.go
+++ b/modules/elastic/api/cluster_overview.go
@@ -888,19 +888,16 @@ func (h *APIHandler) getIndexQPS(clusterID string, bucketSizeInSeconds int) (map
 	}
 
 	partition_num := 10
+	if v1.GetIndicesCount(clusterID) < 200 {
+		partition_num = 1
+	}
 	term_index := util.MapStr{
 		"field": "metadata.labels.index_name",
-		"size":  1000,
-	}
-	if v1.GetIndicesCount(clusterID) > 200 {
-		term_index = util.MapStr{
-			"field": "metadata.labels.index_name",
-			"include": util.MapStr{
-				"partition":      0,
-				"num_partitions": partition_num,
-			},
-			"size": 10000,
-		}
+		"include": util.MapStr{
+			"partition":      0,
+			"num_partitions": partition_num,
+		},
+		"size": 10000,
 	}
 
 	query := util.MapStr{

--- a/modules/elastic/api/index_metrics.go
+++ b/modules/elastic/api/index_metrics.go
@@ -866,19 +866,16 @@ func (h *APIHandler) getTopIndexName(req *http.Request, clusterID string, top in
 	}
 
 	partition_num := 10
+	if v1.GetIndicesCount(clusterID) < 200 {
+		partition_num = 1
+	}
 	term_index := util.MapStr{
 		"field": "metadata.labels.index_name",
-		"size":  1000,
-	}
-	if v1.GetIndicesCount(clusterID) > 200 {
-		term_index = util.MapStr{
-			"field": "metadata.labels.index_name",
-			"include": util.MapStr{
-				"partition":      0,
-				"num_partitions": partition_num,
-			},
-			"size": 10000,
-		}
+		"include": util.MapStr{
+			"partition":      0,
+			"num_partitions": partition_num,
+		},
+		"size": 10000,
 	}
 
 	query := util.MapStr{

--- a/modules/elastic/api/v1/cluster_overview.go
+++ b/modules/elastic/api/v1/cluster_overview.go
@@ -682,19 +682,16 @@ func (h *APIHandler) getIndexQPS(clusterID string, bucketSizeInSeconds int) (map
 	}
 
 	partition_num := 10
+	if GetIndicesCount(clusterID) < 200 {
+		partition_num = 1
+	}
 	term_index := util.MapStr{
 		"field": "metadata.labels.index_name",
-		"size":  1000,
-	}
-	if GetIndicesCount(clusterID) > 200 {
-		term_index = util.MapStr{
-			"field": "metadata.labels.index_name",
-			"include": util.MapStr{
-				"partition":      0,
-				"num_partitions": partition_num,
-			},
-			"size": 10000,
-		}
+		"include": util.MapStr{
+			"partition":      0,
+			"num_partitions": partition_num,
+		},
+		"size": 10000,
 	}
 
 	query := util.MapStr{

--- a/modules/elastic/api/v1/index_metrics.go
+++ b/modules/elastic/api/v1/index_metrics.go
@@ -796,19 +796,16 @@ func (h *APIHandler) getTopIndexName(req *http.Request, clusterID string, top in
 	}
 
 	partition_num := 10
+	if GetIndicesCount(clusterID) < 200 {
+		partition_num = 1
+	}
 	term_index := util.MapStr{
 		"field": "metadata.labels.index_name",
-		"size":  1000,
-	}
-	if GetIndicesCount(clusterID) > 200 {
-		term_index = util.MapStr{
-			"field": "metadata.labels.index_name",
-			"include": util.MapStr{
-				"partition":      0,
-				"num_partitions": partition_num,
-			},
-			"size": 10000,
-		}
+		"include": util.MapStr{
+			"partition":      0,
+			"num_partitions": partition_num,
+		},
+		"size": 10000,
 	}
 
 	query := util.MapStr{

--- a/plugin/api/index_management/elasticsearch.go
+++ b/plugin/api/index_management/elasticsearch.go
@@ -452,21 +452,20 @@ func (handler APIHandler) getGroupMetric(indexName, field string, filter interfa
 func (h *APIHandler) ClusterOverTreeMap(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 
 	clusterID := ps.ByName("id")
+
 	partition_num := 10
+	if v1.GetIndicesCount(clusterID) < 200 {
+		partition_num = 1
+	}
 	term_index := util.MapStr{
 		"field": "metadata.labels.index_name",
-		"size":  1000,
+		"include": util.MapStr{
+			"partition":      0,
+			"num_partitions": partition_num,
+		},
+		"size": 10000,
 	}
-	if v1.GetIndicesCount(clusterID) > 200 {
-		term_index = util.MapStr{
-			"field": "metadata.labels.index_name",
-			"include": util.MapStr{
-				"partition":      0,
-				"num_partitions": partition_num,
-			},
-			"size": 10000,
-		}
-	}
+
 	queryLatency := util.MapStr{
 		"size": 0,
 		"aggs": util.MapStr{


### PR DESCRIPTION
## What does this PR do
This pull request refactors the logic for determining the partitioning strategy in multiple API handler methods across different files. The changes aim to simplify and standardize the code by dynamically adjusting the partition number based on the number of indices in a cluster. The most important changes are grouped below:

### Partitioning Logic Refactor:

* Updated the partitioning logic in `getIndexQPS` and `getTopIndexName` methods to dynamically set `partition_num` to 1 if the number of indices in a cluster is less than 200. This replaces the previous hardcoded logic and ensures consistent behavior. (`modules/elastic/api/cluster_overview.go`, `modules/elastic/api/index_metrics.go`) [[1]](diffhunk://#diff-26a213a79b6682ebfed27b4b8304578e084b0304fd54af4adee5e2441a25a3ceL891-L904) [[2]](diffhunk://#diff-0c817107e236b70d8792191ab489ef123066adc1b0070117cc599ad1351c803bL869-L882)

* Applied the same dynamic partitioning logic in the corresponding methods within the `v1` package to maintain consistency across versions. (`modules/elastic/api/v1/cluster_overview.go`, `modules/elastic/api/v1/index_metrics.go`) [[1]](diffhunk://#diff-a6f448cb36a7a94fee0b86a9a27c925bd85eca74567201902b5b3a3337d8e135L685-L698) [[2]](diffhunk://#diff-88ae1092c55a4a78fb293abaa1e8e7de6d362aa2796f224b82f09623cb9b6bd3L799-L812)

* Refactored the `getGroupMetric` method in the Elasticsearch plugin to use the updated partitioning logic, ensuring alignment with the new standard. (`plugin/api/index_management/elasticsearch.go`)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation