### PR TITLE
fix: node/index metrics cluster id which not the select cluster id

### DIFF
--- a/modules/elastic/api/cluster_overview.go
+++ b/modules/elastic/api/cluster_overview.go
@@ -678,7 +678,7 @@ func (h *APIHandler) GetClusterNodes(w http.ResponseWriter, req *http.Request, p
 					if nodeInfos[v]["timestamp"] != nil {
 						if ts, ok := nodeInfos[v]["timestamp"].(string); ok {
 							tt, _ := time.Parse(time.RFC3339, ts)
-							if time.Now().Sub(tt).Seconds() > 30 {
+							if time.Now().Sub(tt).Seconds() > 300 {
 								ninfo["status"] = "unavailable"
 							}
 						}

--- a/web/src/pages/Platform/Overview/Indices/Monitor/index.jsx
+++ b/web/src/pages/Platform/Overview/Indices/Monitor/index.jsx
@@ -9,7 +9,7 @@ import ShardStatisticBar from "./shard_statistic_bar";
 import { connect } from "dva";
 
 const Page = (props) => {
-  const { clusterStatus, selectedCluster } = props;
+  const { clusterStatus, clusterList, selectedCluster } = props;
   const {shard_id} = props.location.query;
   const panes = React.useMemo(()=>{
     const panes = [
@@ -28,7 +28,7 @@ const Page = (props) => {
   }
   return (
     <Monitor
-      selectedCluster={selectedCluster}
+      selectedCluster={props.match.params?.cluster_id === selectedCluster?.id ? selectedCluster : clusterList.find((item) => item.id === props.match.params?.cluster_id)}
       formatState={(state) => {
         return {
           ...state,
@@ -86,5 +86,6 @@ const Page = (props) => {
 
 export default connect(({ global }) => ({
   selectedCluster: global.selectedCluster,
+  clusterList: global.clusterList,
   clusterStatus: global.clusterStatus,
 }))(Page);

--- a/web/src/pages/Platform/Overview/Node/Monitor/index.jsx
+++ b/web/src/pages/Platform/Overview/Node/Monitor/index.jsx
@@ -15,10 +15,10 @@ const panes = [
   { title: "Shards", component: Shards, key: "shards" },
 ];
 const Page = (props) => {
-  const { clusterStatus, selectedCluster } = props;
+  const { clusterStatus, clusterList, selectedCluster } = props;
   return (
     <Monitor
-      selectedCluster={selectedCluster}
+      selectedCluster={props.match.params?.cluster_id === selectedCluster?.id ? selectedCluster : clusterList.find((item) => item.id === props.match.params?.cluster_id)}
       formatState={(state) => {
         return {
           ...state,
@@ -61,5 +61,6 @@ const Page = (props) => {
 
 export default connect(({ global }) => ({
   selectedCluster: global.selectedCluster,
+  clusterList: global.clusterList,
   clusterStatus: global.clusterStatus,
 }))(Page);


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the cluster monitoring logic in both backend and frontend code. The backend change increases the timeout threshold for marking a node as unavailable, while the frontend changes enhance cluster selection functionality by incorporating a list of clusters (`clusterList`) to handle scenarios where the selected cluster is not directly matched.

### Backend Change:
* **Node availability timeout adjustment**: Increased the timeout threshold for marking a cluster node as "unavailable" from 30 seconds to 300 seconds in the `GetClusterNodes` API handler. This change provides a more lenient window for nodes to respond before being flagged as unavailable. (`modules/elastic/api/cluster_overview.go`, [modules/elastic/api/cluster_overview.goL681-R681](diffhunk://#diff-26a213a79b6682ebfed27b4b8304578e084b0304fd54af4adee5e2441a25a3ceL681-R681))

### Frontend Changes:
#### Cluster selection improvements:
* **Cluster list integration in `Indices Monitor` page**: Updated the `Indices Monitor` page to use `clusterList` for determining the selected cluster when the `cluster_id` parameter in the URL does not match the currently selected cluster. (`web/src/pages/Platform/Overview/Indices/Monitor/index.jsx`, [[1]](diffhunk://#diff-8c1c326fd1ccac985608212c192745cff8f26b87d94f2dd9f198110d5e5117e1L12-R12) [[2]](diffhunk://#diff-8c1c326fd1ccac985608212c192745cff8f26b87d94f2dd9f198110d5e5117e1L31-R31) [[3]](diffhunk://#diff-8c1c326fd1ccac985608212c192745cff8f26b87d94f2dd9f198110d5e5117e1R89)
* **Cluster list integration in `Node Monitor` page**: Applied the same logic to the `Node Monitor` page, ensuring consistent behavior for cluster selection across different monitoring views. (`web/src/pages/Platform/Overview/Node/Monitor/index.jsx`, [[1]](diffhunk://#diff-3dcf39d602d52c782f9346af446477575f549da0c6e6d792a35a13dea87bf398L18-R21) [[2]](diffhunk://#diff-3dcf39d602d52c782f9346af446477575f549da0c6e6d792a35a13dea87bf398R64)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation