### PR TITLE
improve: add custom timeout error for metric request

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,7 @@ Information about release notes of INFINI Console is provided here.
 - fix: Optimize the display of axis labels in the chart on the monitor
 - fix: stats not refreshed after changing metric level
 ### ✈️ Improvements  
+- improvement: add custom timeout error for metric request
 
 ## 1.29.7 (2025-06-29)
 ### ❌ Breaking changes  

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -13,6 +13,7 @@ title: "版本历史"
 ### 🐛 Bug fix  
 - fix: 修复指标级别变更之后采集状态未更新的问题
 ### ✈️ Improvements  
+- improvement: 优化指标查询超时错误提示
 
 ## 1.29.7 (2025-06-29)
 ### ❌ Breaking changes  

--- a/modules/elastic/api/index_overview.go
+++ b/modules/elastic/api/index_overview.go
@@ -1032,13 +1032,13 @@ func (h *APIHandler) GetSingleIndexMetrics(w http.ResponseWriter, req *http.Requ
 			h.WriteError(w, err, http.StatusInternalServerError)
 		}
 	}
-	if _, ok := metrics[metricKey]; ok {
-		if metrics[metricKey].HitsTotal > 0 && metrics[metricKey].MinBucketSize == 0 {
+	if metricItem, ok := metrics[metricKey]; ok && metricItem != nil {
+		if metricItem.HitsTotal > 0 && metricItem.MinBucketSize == 0 {
 			minBucketSize, err := v1.GetMetricMinBucketSize(clusterID, metricType)
 			if err != nil {
 				log.Error(err)
 			} else {
-				metrics[metricKey].MinBucketSize = int64(minBucketSize)
+				metricItem.MinBucketSize = int64(minBucketSize)
 			}
 		}
 	}

--- a/modules/elastic/api/metrics_util.go
+++ b/modules/elastic/api/metrics_util.go
@@ -25,13 +25,16 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	v1 "infini.sh/console/modules/elastic/api/v1"
-	"infini.sh/framework/core/env"
 	"strings"
 	"time"
 
+	v1 "infini.sh/console/modules/elastic/api/v1"
+	"infini.sh/framework/core/env"
+
 	log "github.com/cihub/seelog"
+	cerr "infini.sh/console/core/errors"
 	"infini.sh/framework/core/elastic"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
@@ -115,6 +118,9 @@ func (h *APIHandler) getMetrics(ctx context.Context, term_level string, query ma
 	queryDSL := util.MustToJSONBytes(query)
 	response, err := elastic.GetClient(global.MustLookupString(elastic.GlobalSystemElasticsearchID)).QueryDSL(ctx, getAllMetricsIndex(), nil, queryDSL)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, cerr.New(cerr.ErrTypeRequestTimeout, "", err)
+		}
 		return nil, err
 	}
 	grpMetricItemsIndex := map[string]int{}
@@ -1116,6 +1122,9 @@ func parseSingleIndexMetrics(ctx context.Context, term_level, clusterID string, 
 	queryDSL := util.MustToJSONBytes(query)
 	response, err := elastic.GetClient(clusterID).QueryDSL(ctx, getAllMetricsIndex(), nil, util.MustToJSONBytes(query))
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, cerr.New(cerr.ErrTypeRequestTimeout, "", err)
+		}
 		return nil, err
 	}
 

--- a/modules/elastic/api/v1/metrics_util.go
+++ b/modules/elastic/api/v1/metrics_util.go
@@ -25,6 +25,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -36,6 +37,7 @@ import (
 	"infini.sh/framework/core/env"
 
 	log "github.com/cihub/seelog"
+	cerr "infini.sh/console/core/errors"
 	"infini.sh/framework/core/elastic"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
@@ -119,6 +121,9 @@ func (h *APIHandler) getMetrics(ctx context.Context, query map[string]interface{
 	queryDSL := util.MustToJSONBytes(query)
 	response, err := elastic.GetClient(global.MustLookupString(elastic.GlobalSystemElasticsearchID)).QueryDSL(ctx, getAllMetricsIndex(), nil, queryDSL)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, cerr.New(cerr.ErrTypeRequestTimeout, "", err)
+		}
 		return nil, err
 	}
 	grpMetricItemsIndex := map[string]int{}
@@ -518,6 +523,9 @@ func (h *APIHandler) getSingleMetrics(ctx context.Context, metricItems []*common
 	queryDSL := util.MustToJSONBytes(query)
 	response, err := elastic.GetClient(clusterID).QueryDSL(ctx, getAllMetricsIndex(), nil, queryDSL)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, cerr.New(cerr.ErrTypeRequestTimeout, "", err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## What does this PR do
add custom timeout error for metric request
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation