### PR TITLE
docs: update tableOfContents start level to 2

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -19,7 +19,7 @@ markup:
     renderer:
       unsafe: true
   tableOfContents:
-    startLevel: 1
+    startLevel: 2
 
 # Multi-lingual mode config
 # There are different options to translate files
@@ -35,7 +35,6 @@ languages:
     languageName: 简体中文
     contentDir: content.zh
     weight: 4
-
 
 menu:
   before: []
@@ -60,7 +59,7 @@ params:
 
   # (Optional, default none) Set leaf bundle to render as side menu
   # When not specified file structure and weights will be used
-#  BookMenuBundle: /menu
+  #  BookMenuBundle: /menu
 
   # (Optional, default docs) Specify root page to render child pages as menu.
   # Page is resoled by .GetPage function: https://gohugo.io/functions/getpage/


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation