### PR TITLE
chore: add gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ config/generated.go
 config/generat*.go
 config/initialization.dsl
 config/system_config.yml
+plugin/enterprise

--- a/web/config/.gitignore
+++ b/web/config/.gitignore
@@ -1,0 +1,1 @@
+router.enterprise.js

--- a/web/src/locales/.gitignore
+++ b/web/src/locales/.gitignore
@@ -1,0 +1,1 @@
+migration.js

--- a/web/src/pages/.gitignore
+++ b/web/src/pages/.gitignore
@@ -1,0 +1,1 @@
+DataTools


### PR DESCRIPTION
## What does this PR do

Adds missing gitignore placeholders for generated or empty web subdirectories so those paths can stay in the repository without carrying incidental files.

## Rationale for this change

This is a standalone repo-hygiene change extracted from the larger branch so it can be reviewed independently and does not mix with functional work.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [x] Performance tests checked, no obvious performance degradation