### PR TITLE
fix: keep alert rule status neutral until info loads

### DIFF
--- a/web/src/pages/Alerting/Rule/Index.jsx
+++ b/web/src/pages/Alerting/Rule/Index.jsx
@@ -67,6 +67,7 @@ export default (props) => {
     if (ruleInfo && !ruleInfo.error) {
       let tableData = dataSource?.data?.map((item) => {
         item.info = ruleInfo?.[item.id] || {};
+        item.infoLoaded = true;
         return item;
       });
       dataSource.data = tableData;
@@ -245,6 +246,15 @@ export default (props) => {
     return dataNew;
   };
 
+  const renderRuleStatus = (record) => {
+    if (!record?.infoLoaded) {
+      return <span style={{ width: 14, height: 14, display: "inline-block" }} />;
+    }
+    return (
+      <HealthStatusCircle status={RuleStautsColor[record.info?.status] || "gray"} />
+    );
+  };
+
   const columns = [
     {
       title: formatMessage({ id: "alert.rule.table.columnns.category" }),
@@ -272,7 +282,7 @@ export default (props) => {
             to={`/alerting/rule/${record.id}`}
             style={{ display: "flex", alignItems: "center", gap: 5 }}
           >
-            <HealthStatusCircle status={RuleStautsColor[record.info?.status]} />
+            {renderRuleStatus(record)}
             <span>{text}</span>
           </Link>
         );


### PR DESCRIPTION
## What does this PR do

Keeps the alerting rule list status indicator neutral until rule health info has finished loading, instead of briefly showing an incorrect state first.

## Rationale for this change

This extracts a small UI behavior fix from the larger branch so the alerting status experience can be reviewed independently from unrelated alerting and frontend changes.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [x] Performance tests checked, no obvious performance degradation