### PR TITLE
improve: align overview news card heights

### DIFF
--- a/web/src/pages/Overview/components/Activities/index.less
+++ b/web/src/pages/Overview/components/Activities/index.less
@@ -1,17 +1,27 @@
 .activities {
   width: 100%;
   height: 100%;
-  max-height: 536px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 
   :global {
-    .ant-card-body {
-      width: 100%;
+    .ant-card {
       height: 100%;
     }
 
-    .ant-timeline {
-      height: calc(100% - 12px);
+    .ant-card-body {
+      width: 100%;
+      height: 100%;
       overflow: hidden;
+    }
+
+    .ant-timeline {
+      height: 100%;
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding-right: 8px;
+      margin-right: -8px;
     }
     .ant-timeline-item {
       margin-bottom: -20px;
@@ -39,6 +49,8 @@
 
   .content {
     width: 100%;
-    height: calc(100% - 29px);
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
   }
 }

--- a/web/src/pages/Overview/components/Product/index.less
+++ b/web/src/pages/Overview/components/Product/index.less
@@ -1,6 +1,6 @@
 .product {
-    height: calc(100% - 325px);
-    max-height: 211px;
+    display: flex;
+    flex-direction: column;
 
     .title {
         font-weight: 700;
@@ -10,13 +10,10 @@
     }
 
     .content {
-        height: calc(100% - 29px);
-        overflow-y: auto;
-
         :global {
             .ant-card-body {
                 width: 100%;    
-                height: 100%;
+                height: auto;
             }
         }
 

--- a/web/src/pages/Overview/index.jsx
+++ b/web/src/pages/Overview/index.jsx
@@ -8,7 +8,7 @@ import Disk from "./components/Disk";
 import Quick from "./components/Quick";
 import Product from "./components/Product";
 import Activities from "./components/Activities";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import request from "@/utils/request";
 import { GREEN, GREY, RED, YELLOW } from "./components/PieChart";
 import IconTitle from "./components/IconTitle";
@@ -16,6 +16,7 @@ import ClustersSvg from "@/components/Icons/Clusters";
 import NodesSvg from "@/components/Icons/Nodes";
 import HostsSvg from "@/components/Icons/Hosts";
 import DiskSvg from "@/components/Icons/DB";
+import useResizeObserver from "@react-hook/resize-observer";
 
 const STATUS = [
   {
@@ -67,6 +68,8 @@ export default connect(({ user }) => ({
 
   const [status, setStatus] = useState({});
   const [loading, setLoading] = useState(false);
+  const leftNewsColumnRef = useRef(null);
+  const [newsColumnHeight, setNewsColumnHeight] = useState();
 
   const fetchStatus = async () => {
     setLoading(true);
@@ -80,6 +83,22 @@ export default connect(({ user }) => ({
   useEffect(() => {
     fetchStatus();
   }, []);
+
+  useEffect(() => {
+    if (
+      leftNewsColumnRef.current &&
+      typeof leftNewsColumnRef.current.getBoundingClientRect === "function"
+    ) {
+      setNewsColumnHeight(leftNewsColumnRef.current.getBoundingClientRect().height);
+    }
+  }, []);
+
+  useResizeObserver(leftNewsColumnRef, (entry) => {
+    const nextHeight = Math.ceil(entry.contentRect.height);
+    if (nextHeight > 0) {
+      setNewsColumnHeight(nextHeight);
+    }
+  });
 
   return (
     <div className={styles.overview}>
@@ -114,13 +133,20 @@ export default connect(({ user }) => ({
       <Row
         gutter={8}
         className={styles.news}
-        style={{ height: "calc(100vh - 420px - 16px - 16px)", minHeight: 536 }}
       >
-        <Col sm={24} md={24} lg={12} style={{ marginBottom: 16 }}>
-          <Quick />
-          <Product />
+        <Col sm={24} md={24} lg={12} className={styles.stackColumn}>
+          <div className={styles.stackColumnInner} ref={leftNewsColumnRef}>
+            <Quick />
+            <Product />
+          </div>
         </Col>
-        <Col sm={24} md={24} lg={12}>
+        <Col
+          sm={24}
+          md={24}
+          lg={12}
+          className={styles.fillColumn}
+          style={newsColumnHeight ? { height: newsColumnHeight } : undefined}
+        >
           <Activities />
         </Col>
       </Row>

--- a/web/src/pages/Overview/index.less
+++ b/web/src/pages/Overview/index.less
@@ -30,4 +30,23 @@
             align-items: center
         }
     }
+
+    .news {
+        :global {
+            .ant-col {
+                height: auto;
+            }
+        }
+    }
+
+    .stackColumn {
+        .stackColumnInner {
+            display: flex;
+            flex-direction: column;
+        }
+    }
+
+    .fillColumn {
+        display: flex;
+    }
 }


### PR DESCRIPTION
## What does this PR do

Adjusts the overview page news section so the product updates card shrinks to its content while the activities panel tracks the left column height more cleanly.

## Rationale for this change

This keeps a small homepage layout improvement isolated from the larger branch so the visual adjustment can be reviewed independently.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [x] Performance tests checked, no obvious performance degradation