### PR TITLE
improve: dedupe repeated frontend error notifications

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -27,6 +27,15 @@ import { setSetupRequired } from "@/utils/setup";
 import { getHealth } from "@/services/system"
 import PlatformContainer from "./components/PlatformContainer";
 import React from "react";
+import { message, notification } from "antd";
+
+message.config({
+  maxCount: 3,
+});
+
+notification.config({
+  placement: "topRight",
+});
 
 if (!String.prototype.replaceAll) {
   String.prototype.replaceAll = function(search, replacement) {

--- a/web/src/utils/request.js
+++ b/web/src/utils/request.js
@@ -31,6 +31,40 @@ export const formatResponse = (response) => {
   }
 }
 
+const ERROR_NOTIFICATION_DEDUPE_MS = 4000;
+const recentErrorNotifications = new Map();
+
+const cleanupRecentErrorNotifications = (now = Date.now()) => {
+  recentErrorNotifications.forEach((timestamp, key) => {
+    if (now - timestamp >= ERROR_NOTIFICATION_DEDUPE_MS) {
+      recentErrorNotifications.delete(key);
+    }
+  });
+};
+
+const showErrorNotification = ({
+  message,
+  description,
+  style,
+  dedupeKey,
+}) => {
+  const now = Date.now();
+  cleanupRecentErrorNotifications(now);
+  const key = dedupeKey || `${message}`;
+  const lastShownAt = recentErrorNotifications.get(key);
+  if (lastShownAt && now - lastShownAt < ERROR_NOTIFICATION_DEDUPE_MS) {
+    return;
+  }
+  recentErrorNotifications.set(key, now);
+  notification.error({
+    key,
+    placement: "topRight",
+    message,
+    description,
+    style,
+  });
+};
+
 const checkStatus = async (response, noticeable, option={}) => {
   const codeMessage = {
     200: formatMessage({ id: "app.message.http.status.200" }),
@@ -88,10 +122,11 @@ const checkStatus = async (response, noticeable, option={}) => {
             {desc}
           </div>
         );
-        notification.error({
+        showErrorNotification({
           message: formatMessage({ id: "app.message.http.request.error" }),
           description: desc,
           style: { wordBreak: "break-all" },
+          dedupeKey: `http-500:${typeof jsonRes.error === "string" ? jsonRes.error : jsonRes.error?.reason || response.status}`,
         });
       }
       return response;
@@ -104,10 +139,11 @@ const checkStatus = async (response, noticeable, option={}) => {
     option.hasOwnProperty("showErrorInner") &&
     option.showErrorInner === true
   ) {
-    notification.error({
+    showErrorNotification({
       message: response.statusText,
       description: errortext,
       style: { wordBreak: "break-all" },
+      dedupeKey: `http-inner:${response.status}:${response.statusText}:${errortext}`,
     });
     return response;
   }
@@ -136,10 +172,11 @@ const checkStatus = async (response, noticeable, option={}) => {
           {errortext}
         </div>
       );
-      notification.error({
+      showErrorNotification({
         message: `${formatMessage({ id: "app.message.http.request.error" })}`,
         description: desc,
         style: { wordBreak: "break-all" },
+        dedupeKey: `http-status:${response.status}:${errortext}`,
       });
     }
   }


### PR DESCRIPTION
## What does this PR do

Deduplicates repeated frontend error notifications within a short window and caps concurrent global messages so failures no longer flood the screen.

## Rationale for this change

This extracts a focused frontend UX improvement from the larger branch so notification behavior can be reviewed independently from the other runtime and security changes.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [x] Performance tests checked, no obvious performance degradation