### PR TITLE
improve: increase DevTools editor readability

### DIFF
--- a/web/src/components/vendor/console/components/ConsoleInput.tsx
+++ b/web/src/components/vendor/console/components/ConsoleInput.tsx
@@ -28,6 +28,10 @@ import { applyCurrentSettings } from "./apply_editor_settings";
 import { subscribeResizeChecker } from "./subscribe_console_resize_checker";
 import { formatMessage } from "umi/locale";
 
+const isMacPlatform = () =>
+  typeof window !== "undefined" &&
+  /(Mac|iPhone|iPad|iPod)/i.test(window.navigator.platform);
+
 const abs: CSSProperties = {
   position: "absolute",
   top: "0",
@@ -47,6 +51,10 @@ const abs: CSSProperties = {
 const SendRequestButton = (props: any) => {
   const sendCurrentRequestToES = useSendCurrentRequestToES();
   const saveCurrentTextObject = useSaveCurrentTextObject();
+  const sendShortcutLabel = isMacPlatform() ? "Cmd+Enter" : "Ctrl+Enter";
+  const tooltipContent = `${formatMessage({
+    id: "console.SendRequestButton.ToolTip",
+  })} (${sendShortcutLabel})`;
 
   const { saveCurrentTextObjectRef } = props;
   useEffect(() => {
@@ -54,12 +62,10 @@ const SendRequestButton = (props: any) => {
   }, [saveCurrentTextObjectRef]);
 
   return (
-    <EuiToolTip
-      content={formatMessage({ id: "console.SendRequestButton.ToolTip" })}
-    >
+    <EuiToolTip content={tooltipContent}>
       <button
         data-test-subj="sendRequestButton"
-        aria-label={"Click to send request"}
+        aria-label={tooltipContent}
         className="conApp__editorActionButton conApp__editorActionButton--success"
         onClick={sendCurrentRequestToES}
       >
@@ -137,7 +143,7 @@ const ConsoleInputUI = ({
     senseEditor.paneKey = paneKey;
     senseEditor.update(initialText || DEFAULT_INPUT_VALUE);
     applyCurrentSettings(senseEditor!.getCoreEditor(), {
-      fontSize: 12,
+      fontSize: 13,
       wrapMode: true,
     });
 

--- a/web/src/components/vendor/console/components/ConsoleOutput.tsx
+++ b/web/src/components/vendor/console/components/ConsoleOutput.tsx
@@ -53,7 +53,7 @@ function ConsoleOutput({ clusterID }: props) {
     textarea.setAttribute("id", inputId);
     textarea.setAttribute("readonly", "true");
     applyCurrentSettings(editorInstanceRef.current!, {
-      fontSize: 12,
+      fontSize: 13,
       wrapMode: true,
     });
     const unsubscribeResizer = subscribeResizeChecker(

--- a/web/src/components/vendor/console/components/apply_editor_settings.ts
+++ b/web/src/components/vendor/console/components/apply_editor_settings.ts
@@ -21,6 +21,9 @@ import { DevToolsSettings } from '../services';
 import { CoreEditor } from '../entities/core_editor';
 import { CustomAceEditor } from '../modules/legacy_core_editor/create_readonly';
 
+const CONSOLE_FONT_FAMILY =
+  '"JetBrains Mono","SFMono-Regular","Cascadia Code","Fira Code",Consolas,"Liberation Mono",Menlo,monospace';
+
 export function applyCurrentSettings(
   editor: CoreEditor | CustomAceEditor,
   settings: DevToolsSettings
@@ -34,4 +37,10 @@ export function applyCurrentSettings(
     (editor as CustomAceEditor).getSession().setUseWrapMode(settings.wrapMode);
     (editor as CustomAceEditor).container.style.fontSize = settings.fontSize + 'px';
   }
+
+  const container =
+    typeof (editor as any).getContainer === 'function'
+      ? (editor as CoreEditor).getContainer()
+      : (editor as CustomAceEditor).container;
+  container.style.fontFamily = CONSOLE_FONT_FAMILY;
 }

--- a/web/src/components/vendor/console/services/settings.ts
+++ b/web/src/components/vendor/console/services/settings.ts
@@ -35,7 +35,7 @@ export class Settings {
   constructor(private readonly storage: Storage) {}
 
   getFontSize() {
-    return this.storage.get('font_size', 12);
+    return this.storage.get('font_size', 13);
   }
 
   setFontSize(size: any) {


### PR DESCRIPTION
## What does this PR do

Improves DevTools editor readability by using a more readable monospace font stack, bumping the default editor font size, and surfacing the send-request shortcut in the button tooltip.

## Rationale for this change

This extracts a focused DevTools UX improvement from the larger branch so editor readability can be reviewed independently from other console and runtime changes.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [x] Performance tests checked, no obvious performance degradation