### PR TITLE
improve: harden web build and install workflow

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -36,3 +36,5 @@ log/
 /web/
 .github
 src/common*/
+/public
+plugin/enterprise/

--- a/web/package.json
+++ b/web/package.json
@@ -118,6 +118,7 @@
     "babel-plugin-dva-hmr": "^0.4.1",
     "babel-plugin-import": "^1.6.3",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "chokidar": "^5.0.0",
     "cross-env": "^7.0.3",
     "enzyme": "^3.9.0",
     "eslint": "^4.18.2",
@@ -137,10 +138,10 @@
     "sass": "1.69.5",
     "sass-loader": "8.0.2",
     "ts-loader": "8.4.0",
+    "typescript": "4.9.5",
     "umi": "^2.1.2",
     "umi-plugin-ga": "^1.1.3",
-    "umi-plugin-react": "^1.1.1",
-    "typescript": "4.9.5"
+    "umi-plugin-react": "^1.1.1"
   },
   "engines": {
     "node": ">=8.9.0"
@@ -155,9 +156,10 @@
     "@antv/l7-component": "2.23.0"
   },
   "scripts": {
-    "dev": "cross-env MOCK=none UMI_UI=none NODE_OPTIONS=\"--max_old_space_size=4096\" umi dev",
-    "mock": "cross-env UMI_UI=none NODE_OPTIONS=\"--max_old_space_size=4096\" umi dev",
-    "build": "NODE_OPTIONS=\"--max_old_space_size=4096  --trace-deprecation\" umi build && cp -R  static/* ../.public/static/",
+    "preinstall": "node ./scripts/ensure-cnpm.js",
+    "dev": "cross-env HTTPS=true MOCK=none node ./scripts/run-umi.js dev",
+    "mock": "node ./scripts/run-umi.js dev",
+    "build": "node ./scripts/run-umi.js build && cp -R static/* ../.public/static/",
     "autod": "autod",
     "docker:dev": "docker-compose -f ./docker/docker-compose.dev.yml up --remove-orphans -d",
     "docker:stop-dev": "docker-compose -f ./docker/docker-compose.dev.yml  down",

--- a/web/scripts/ensure-cnpm.js
+++ b/web/scripts/ensure-cnpm.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const execPath = `${process.env.npm_execpath || ""}`.toLowerCase();
+const userAgent = `${process.env.npm_config_user_agent || ""}`.toLowerCase();
+
+const isCnpm =
+  execPath.includes("cnpm") ||
+  execPath.includes("npminstall") ||
+  userAgent.includes("cnpm/") ||
+  userAgent.includes("npminstall/");
+
+if (!isCnpm) {
+  console.error("");
+  console.error("This frontend only supports dependency installation via cnpm.");
+  console.error("Please use: cnpm install");
+  console.error("");
+  process.exit(1);
+}

--- a/web/scripts/run-umi.js
+++ b/web/scripts/run-umi.js
@@ -1,0 +1,120 @@
+"use strict";
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const mode = process.argv[2];
+
+if (!mode || !["dev", "build"].includes(mode)) {
+  console.error("usage: node scripts/run-umi.js <dev|build>");
+  process.exit(1);
+}
+
+const syncStaticAssets = () => {
+  const staticDir = path.resolve(__dirname, "../static");
+  const publicStaticDir = path.resolve(__dirname, "../public/static");
+
+  if (!fs.existsSync(staticDir)) {
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(publicStaticDir), { recursive: true });
+  fs.rmSync(publicStaticDir, { recursive: true, force: true });
+  fs.cpSync(staticDir, publicStaticDir, { recursive: true });
+};
+
+const syncPluginDirectory = async () => {
+  const pluginDir = path.resolve(__dirname, "../../plugin/enterprise/web"); 
+  const pagesDir = path.resolve(__dirname, "../");
+
+  if (fs.existsSync(pluginDir)) {
+    console.log("Plugin directory found. Syncing with the main project...");
+
+    try {
+      fs.cpSync(pluginDir, pagesDir, { recursive: true, force: true });
+      console.log(`Plugin synced directly to ${pagesDir}`);
+    } catch (err) {
+      console.error(`Failed to sync plugin to ${pagesDir}:`, err);
+    }
+  } else {
+    console.log("No plugin directory found, skipping sync.");
+  }
+};
+
+const watchPluginChanges = async () => {
+  const chokidar = await import("chokidar"); 
+
+  const pluginDir = path.resolve(__dirname, "../../plugin/enterprise/web");
+  
+  if (fs.existsSync(pluginDir)) {
+    const watcher = chokidar.watch(pluginDir, { persistent: true });
+
+    watcher.on("change", (filePath) => {
+      console.log(`File changed: ${filePath}`);
+      syncPluginDirectory();
+    });
+
+    watcher.on("error", (err) => {
+      console.error("Error watching plugin directory:", err);
+    });
+
+    console.log(`Watching plugin directory for changes: ${pluginDir}`);
+  } else {
+    console.log("Plugin directory not found, skipping file watching.");
+  }
+};
+
+const run = async () => {
+  syncStaticAssets();
+
+  await syncPluginDirectory();
+
+  if (mode === "dev") {
+    await watchPluginChanges(); 
+  }
+
+  const defaultOldSpaceSize =
+    process.env.UMI_MAX_OLD_SPACE_SIZE || (mode === "build" ? "8192" : "4096");
+
+  const nodeMajorVersion = Number(process.versions.node.split(".")[0] || "0");
+  const existingNodeOptions = (process.env.NODE_OPTIONS || "").trim();
+  const optionSet = new Set(existingNodeOptions.split(/\s+/).filter(Boolean));
+
+  if (![...optionSet].some((item) => item.startsWith("--max_old_space_size="))) {
+    optionSet.add(`--max_old_space_size=${defaultOldSpaceSize}`);
+  }
+
+  if (
+    nodeMajorVersion >= 17 &&
+    !optionSet.has("--openssl-legacy-provider")
+  ) {
+    optionSet.add("--openssl-legacy-provider");
+  }
+
+  optionSet.add("--trace-deprecation");
+
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: [...optionSet].join(" "),
+  };
+
+  if (mode === "dev") {
+    env.UMI_UI = env.UMI_UI || "none";
+  }
+
+  const result = spawnSync("./node_modules/.bin/umi", [mode], {
+    stdio: "inherit",
+    shell: true,
+    env,
+  });
+
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+
+  process.exit(result.status || 0);
+};
+
+run();


### PR DESCRIPTION
## What does this PR do

Hardens the web build workflow by routing dev/build through a dedicated `run-umi.js` wrapper, syncing enterprise plugin assets during local work, and enforcing `cnpm` / `npminstall` for dependency installation.

## Rationale for this change

This keeps the web toolchain changes isolated from unrelated runtime and UI behavior changes, making build/install workflow updates easier to review and merge.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [x] Performance tests checked, no obvious performance degradation