### PR TITLE
fix: gate enterprise menus by application settings

### DIFF
--- a/web/config/router.config.js
+++ b/web/config/router.config.js
@@ -1,3 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const pluginRoutes = [];
+
+const pluginRoutePath = path.resolve("config", "router.enterprise.js");
+if (fs.existsSync(pluginRoutePath)) {
+  pluginRoutes.push(...require(pluginRoutePath).default);
+}
+
 export default [
   // user
   {
@@ -155,6 +165,7 @@ export default [
           },
         ],
       },
+      ...pluginRoutes,
 
       // alerting
       {

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -21,7 +21,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import { getAuthEnabled } from "./utils/authority";
+import {
+  getAuthEnabled,
+  getEnterpriseTaskManagerEnabled,
+  refreshApplicationSettings,
+} from "./utils/authority";
 import request from "./utils/request";
 import { setSetupRequired } from "@/utils/setup";
 import { getHealth } from "@/services/system"
@@ -36,8 +40,12 @@ if (!String.prototype.replaceAll) {
 }
 
 export async function patchRoutes(routes) {
+  await refreshApplicationSettings();
   const healthRes = await getHealth();
   setSetupRequired(`${healthRes?.setup_required}`);
+  if (getEnterpriseTaskManagerEnabled() !== "true") {
+    hideRoutesInMenu(routes, ["data_tools"], "");
+  }
   if (getAuthEnabled() === "false") {
     routes = filterRoutes(routes, ["system.security"], "");
     // routes = disableAuth(routes);
@@ -77,6 +85,24 @@ function filterRoutes(routes, names, prefix) {
       route.routes = filterRoutes(route.routes, names, pn);
     }
     return true;
+  });
+}
+
+function hideRoutesInMenu(routes, names, prefix) {
+  (routes || []).forEach((route) => {
+    if (route.name) {
+      const pn = prefix ? `${prefix}.${route.name}` : route.name;
+      if (names.includes(pn)) {
+        route.hideInMenu = true;
+      }
+    }
+    if (route.routes) {
+      let pn = "";
+      if (route.name) {
+        pn = prefix ? `${prefix}.${route.name}` : route.name;
+      }
+      hideRoutesInMenu(route.routes, names, pn);
+    }
   });
 }
 

--- a/web/src/pages/Overview/components/Quick/index.jsx
+++ b/web/src/pages/Overview/components/Quick/index.jsx
@@ -7,51 +7,90 @@ import ClusterIcon from "./icons/ClusterIcon";
 import SecurityIcon from "./icons/SecurityIcon";
 import DiscoverIcon from "./icons/DiscoverIcon";
 import MonitorIcon from "./icons/MonitorIcon";
+import MigrationIcon from "./icons/MigrationIcon";
 import { formatMessage } from "umi/locale";
+import {
+  getEnterpriseTaskManagerEnabled,
+  hasAuthority,
+} from "@/utils/authority";
 
-const ROUTES = [
-  {
-    path: "/resource/cluster",
-    name: "cluster_regist",
-    icon: ClusterIcon,
-  },
-  {
-    path: "/alerting/message",
-    name: "alert",
-    icon: MessageIcon,
-  },
-  {
-    path: "/insight/discover",
-    name: "discover",
-    icon: DiscoverIcon,
-  },
-  {
-    path: "/cluster/monitor",
-    name: "monitor",
-    icon: MonitorIcon,
-  },
-  {
-    path: "/system/security",
-    name: "security",
-    icon: SecurityIcon,
-  },
-  {
-    path: "/devtool/console",
-    name: "dev_tools",
-    icon: DevToolIcon,
-  },
-];
+const getRoutes = () => {
+  const routes = [
+    {
+      path: "/resource/cluster",
+      name: "cluster_regist",
+      icon: ClusterIcon,
+    },
+    {
+      path: "/alerting/message",
+      name: "alert",
+      icon: MessageIcon,
+    },
+    {
+      path: "/insight/discover",
+      name: "discover",
+      icon: DiscoverIcon,
+    },
+    {
+      path: "/cluster/monitor",
+      name: "monitor",
+      icon: MonitorIcon,
+    },
+    {
+      path: "/system/security",
+      name: "security",
+      icon: SecurityIcon,
+    },
+    {
+      path: "/devtool/console",
+      name: "dev_tools",
+      icon: DevToolIcon,
+    },
+  ];
+
+  if (
+    getEnterpriseTaskManagerEnabled() === "true" &&
+    (hasAuthority("data_tools.comparison:all") ||
+      hasAuthority("data_tools.comparison:read"))
+  ) {
+    routes.unshift({
+      path: "/data_tools/comparison",
+      name: "comparison",
+      icon: MigrationIcon,
+    });
+  }
+
+  if (
+    getEnterpriseTaskManagerEnabled() === "true" &&
+    (hasAuthority("data_tools.migration:all") ||
+      hasAuthority("data_tools.migration:read"))
+  ) {
+    routes.unshift({
+      path: "/data_tools/migration",
+      name: "migration",
+      icon: MigrationIcon,
+    });
+  }
+
+  return routes;
+};
 
 export default () => {
+  const routes = getRoutes();
+
   return (
     <div className={styles.quick}>
       <div className={styles.title}>
         {formatMessage({ id: "overview.title.quick" })}
       </div>
       <Row gutter={8}>
-        {ROUTES.map((item, index) => (
+        {routes.map((item, index) => (
           <Col key={index} span={12} className={styles.item}>
-            <Card onClick={() => router.push(item.path)} size="small" bodyStyle={{display:"flex"}}>
+            <Card
+              onClick={() => router.push(item.path)}
+              size="small"
+              bodyStyle={{ display: "flex" }}
+            >
               <div style={{ display: "flex", alignItems: "center" }}>
                 {item.icon && (
                   <Icon className={styles.icon} component={item.icon} />

--- a/web/src/pages/System/Role/Platform/form.jsx
+++ b/web/src/pages/System/Role/Platform/form.jsx
@@ -19,8 +19,9 @@ import TagEditor from "@/components/infini/TagEditor";
 import Permission from "./permission";
 import ApiPermission from "./api_permission";
 import request from "@/utils/request";
-import { menuData } from "./menu";
+import { getMenuData } from "./menu";
 import { formatMessage } from "umi/locale";
+import { refreshApplicationSettings } from "@/utils/authority";
 
 const formItemLayout = {
   labelCol: {
@@ -47,6 +48,7 @@ const tailFormItemLayout = {
 const PlatformRoleForm = (props) => {
   const { getFieldDecorator } = props.form;
   const [isLoading, setIsLoading] = useState(false);
+  const [menuData, setMenuData] = useState(() => getMenuData());
 
   const handleSubmit = useCallback(
     (e) => {
@@ -69,6 +71,18 @@ const PlatformRoleForm = (props) => {
   };
 
   const editValue = props.value || {};
+
+  useEffect(() => {
+    let isMounted = true;
+    refreshApplicationSettings().finally(() => {
+      if (isMounted) {
+        setMenuData(getMenuData());
+      }
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   return (
     <PageHeaderWrapper>

--- a/web/src/pages/System/Role/Platform/menu.js
+++ b/web/src/pages/System/Role/Platform/menu.js
@@ -1,4 +1,6 @@
-export const menuData = [
+import { getEnterpriseTaskManagerEnabled } from "@/utils/authority";
+
+const baseMenuData = [
   { key: "workbench", menuKey: "overview" },
   {
     key: "cluster",
@@ -110,3 +112,23 @@ export const menuData = [
     ],
   },
 ];
+
+const enterpriseTaskMenu = {
+  key: "data_tools",
+  children: [
+    {
+      key: "data_tools.migration",
+    },
+    {
+      key: "data_tools.comparison",
+    },
+  ],
+};
+
+export const getMenuData = () => {
+  const menuData = [...baseMenuData];
+  if (getEnterpriseTaskManagerEnabled() === "true") {
+    menuData.splice(menuData.length - 1, 0, enterpriseTaskMenu);
+  }
+  return menuData;
+};

--- a/web/src/utils/authority.js
+++ b/web/src/utils/authority.js
@@ -1,5 +1,23 @@
 import request from "./request";
 
+const APPLICATION_AUTH_KEY = "infini-auth";
+const APPLICATION_ROLLUP_KEY = "infini-rollup-enabled";
+const ENTERPRISE_TASK_MANAGER_KEY = "infini-enterprise-task-manager-enabled";
+let applicationSettingsPromise = null;
+let applicationSettingsCache = null;
+
+function persistApplicationSettings(res) {
+  localStorage.setItem(APPLICATION_AUTH_KEY, `${res.auth_enabled}`);
+  localStorage.setItem(
+    APPLICATION_ROLLUP_KEY,
+    `${!!res.system_cluster?.rollup_enabled}`
+  );
+  localStorage.setItem(
+    ENTERPRISE_TASK_MANAGER_KEY,
+    `${!!res.enterprise_plugins?.task_manager}`
+  );
+}
+
 // use localStorage to store the authority info, which might be sent from server in actual project.
 export function getAuthority(str) {
   // return localStorage.getItem('infini-console-authority') || ['admin', 'user'];
@@ -37,7 +55,7 @@ export function hasAuthority(authority) {
 }
 
 export function getAuthEnabled() {
-  return localStorage.getItem("infini-auth");
+  return localStorage.getItem(APPLICATION_AUTH_KEY);
 }
 
 export function isLogin() {
@@ -73,13 +91,37 @@ export function getAuthorizationHeader() {
 }
 
 export function getRollupEnabled() {
-  return localStorage.getItem("infini-rollup-enabled");
+  return localStorage.getItem(APPLICATION_ROLLUP_KEY);
+}
+
+export function getEnterpriseTaskManagerEnabled() {
+  return localStorage.getItem(ENTERPRISE_TASK_MANAGER_KEY);
+}
+
+export async function refreshApplicationSettings(force = false) {
+  if (applicationSettingsPromise) {
+    return applicationSettingsPromise;
+  }
+
+  if (!force && applicationSettingsCache) {
+    return applicationSettingsCache;
+  }
+
+  applicationSettingsPromise = request("/setting/application")
+    .then((res) => {
+      if (res && !res.error) {
+        persistApplicationSettings(res);
+        applicationSettingsCache = res;
+      }
+      return res;
+    })
+    .finally(() => {
+      applicationSettingsPromise = null;
+    });
+
+  return applicationSettingsPromise;
 }
 
 (async function() {
-  const res = await request("/setting/application");
-  if (res && !res.error) {
-    localStorage.setItem("infini-auth", res.auth_enabled);
-    localStorage.setItem('infini-rollup-enabled', res.system_cluster?.rollup_enabled || false)
-  }
+  await refreshApplicationSettings();
 })();


### PR DESCRIPTION
## Summary
- cache `/setting/application` and expose the enterprise task manager capability to the shared shell
- load optional enterprise router definitions and hide enterprise-only menu entries when the capability is disabled
- gate overview quick entries and platform role permission tree nodes behind the same application setting

## Testing
- NODE_OPTIONS="--openssl-legacy-provider --max_old_space_size=4096" ./node_modules/.bin/umi build