### PR TITLE
feat: add challenge-based native login

### DIFF
--- a/core/security/password_challenge.go
+++ b/core/security/password_challenge.go
@@ -1,0 +1,154 @@
+package security
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/crypto/pbkdf2"
+	"infini.sh/framework/core/util"
+)
+
+const (
+	PasswordChallengeMethod     = "challenge"
+	PasswordChallengeAlgorithm  = "PBKDF2-SHA256"
+	PasswordChallengeIterations = 120000
+	passwordChallengeKeyLength  = 32
+	loginChallengeTTL           = 5 * time.Minute
+)
+
+type LoginChallenge struct {
+	ID       string
+	Username string
+	Nonce    string
+	ExpireAt time.Time
+}
+
+var loginChallengeLocker sync.Mutex
+var loginChallengeMap = map[string]LoginChallenge{}
+
+func CanUsePasswordChallenge(user *User) bool {
+	return user != nil && user.PasswordSalt != "" && user.PasswordVerifier != ""
+}
+
+func SetPassword(user *User, password string) error {
+	if user == nil {
+		return errors.New("user is nil")
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	salt := util.GenerateSecureString(32)
+	verifier, err := DerivePasswordVerifier(password, salt)
+	if err != nil {
+		return err
+	}
+	user.Password = string(hash)
+	user.PasswordSalt = salt
+	user.PasswordVerifier = verifier
+	return nil
+}
+
+func EnsurePasswordChallenge(user *User, password string) error {
+	if user == nil {
+		return errors.New("user is nil")
+	}
+	if CanUsePasswordChallenge(user) {
+		return nil
+	}
+	salt := util.GenerateSecureString(32)
+	verifier, err := DerivePasswordVerifier(password, salt)
+	if err != nil {
+		return err
+	}
+	user.PasswordSalt = salt
+	user.PasswordVerifier = verifier
+	return nil
+}
+
+func DerivePasswordVerifier(password, salt string) (string, error) {
+	if password == "" {
+		return "", errors.New("password is empty")
+	}
+	if salt == "" {
+		return "", errors.New("password salt is empty")
+	}
+	key := pbkdf2.Key([]byte(password), []byte(salt), PasswordChallengeIterations, passwordChallengeKeyLength, sha256.New)
+	return hex.EncodeToString(key), nil
+}
+
+func BuildPasswordProof(verifier, username, challengeID, nonce string) (string, error) {
+	key, err := hex.DecodeString(verifier)
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(username))
+	mac.Write([]byte(":"))
+	mac.Write([]byte(challengeID))
+	mac.Write([]byte(":"))
+	mac.Write([]byte(nonce))
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+func VerifyPasswordProof(verifier, username, challengeID, nonce, proof string) bool {
+	expected, err := BuildPasswordProof(verifier, username, challengeID, nonce)
+	if err != nil {
+		return false
+	}
+	expectedBytes, err := hex.DecodeString(expected)
+	if err != nil {
+		return false
+	}
+	proofBytes, err := hex.DecodeString(strings.ToLower(proof))
+	if err != nil {
+		return false
+	}
+	return hmac.Equal(expectedBytes, proofBytes)
+}
+
+func NewLoginChallenge(username string) LoginChallenge {
+	now := time.Now()
+	loginChallengeLocker.Lock()
+	defer loginChallengeLocker.Unlock()
+
+	for id, challenge := range loginChallengeMap {
+		if challenge.ExpireAt.Before(now) {
+			delete(loginChallengeMap, id)
+		}
+	}
+
+	challenge := LoginChallenge{
+		ID:       util.GenerateSecureString(32),
+		Username: username,
+		Nonce:    util.GenerateSecureString(32),
+		ExpireAt: now.Add(loginChallengeTTL),
+	}
+	loginChallengeMap[challenge.ID] = challenge
+	return challenge
+}
+
+func ConsumeLoginChallenge(challengeID, username string) (LoginChallenge, error) {
+	loginChallengeLocker.Lock()
+	defer loginChallengeLocker.Unlock()
+
+	challenge, ok := loginChallengeMap[challengeID]
+	if !ok {
+		return LoginChallenge{}, errors.New("login challenge is invalid")
+	}
+	delete(loginChallengeMap, challengeID)
+
+	if challenge.ExpireAt.Before(time.Now()) {
+		return LoginChallenge{}, errors.New("login challenge expired")
+	}
+	if challenge.Username != username {
+		return LoginChallenge{}, errors.New("login challenge does not match user")
+	}
+	return challenge, nil
+}

--- a/core/security/password_challenge_test.go
+++ b/core/security/password_challenge_test.go
@@ -1,0 +1,34 @@
+package security
+
+import "testing"
+
+func TestPasswordChallengeProofRoundTrip(t *testing.T) {
+	verifier, err := DerivePasswordVerifier("admin", "salt-123")
+	if err != nil {
+		t.Fatalf("derive verifier: %v", err)
+	}
+
+	challenge := NewLoginChallenge("admin")
+	proof, err := BuildPasswordProof(verifier, "admin", challenge.ID, challenge.Nonce)
+	if err != nil {
+		t.Fatalf("build proof: %v", err)
+	}
+
+	if !VerifyPasswordProof(verifier, "admin", challenge.ID, challenge.Nonce, proof) {
+		t.Fatal("expected password proof to validate")
+	}
+}
+
+func TestSetPasswordEnablesChallengeLogin(t *testing.T) {
+	user := &User{}
+	if err := SetPassword(user, "admin"); err != nil {
+		t.Fatalf("set password: %v", err)
+	}
+
+	if user.Password == "" || user.PasswordSalt == "" || user.PasswordVerifier == "" {
+		t.Fatal("expected password, salt and verifier to be populated")
+	}
+	if !CanUsePasswordChallenge(user) {
+		t.Fatal("expected challenge login to be enabled")
+	}
+}

--- a/core/security/user.go
+++ b/core/security/user.go
@@ -34,13 +34,15 @@ import (
 type User struct {
 	orm.ORMObjectBase
 
-	AuthProvider string   `json:"auth_provider"  elastic_mapping:"auth_provider: { type: keyword }"`
-	Username     string   `json:"name"  elastic_mapping:"name: { type: keyword }"`
-	Nickname     string   `json:"nick_name"  elastic_mapping:"nick_name: { type: keyword }"`
-	Password     string   `json:"password"  elastic_mapping:"password: { type: keyword }"`
-	Email        string   `json:"email" elastic_mapping:"email: { type: keyword }"`
-	Phone        string   `json:"phone" elastic_mapping:"phone: { type: keyword }"`
-	Tags         []string `json:"tags" elastic_mapping:"mobile: { type: keyword }"`
+	AuthProvider     string   `json:"auth_provider"  elastic_mapping:"auth_provider: { type: keyword }"`
+	Username         string   `json:"name"  elastic_mapping:"name: { type: keyword }"`
+	Nickname         string   `json:"nick_name"  elastic_mapping:"nick_name: { type: keyword }"`
+	Password         string   `json:"password"  elastic_mapping:"password: { type: keyword }"`
+	PasswordSalt     string   `json:"password_salt,omitempty" elastic_mapping:"password_salt: { type: keyword }"`
+	PasswordVerifier string   `json:"password_verifier,omitempty" elastic_mapping:"password_verifier: { type: keyword }"`
+	Email            string   `json:"email" elastic_mapping:"email: { type: keyword }"`
+	Phone            string   `json:"phone" elastic_mapping:"phone: { type: keyword }"`
+	Tags             []string `json:"tags" elastic_mapping:"mobile: { type: keyword }"`
 
 	AvatarUrl string      `json:"avatar_url" elastic_mapping:"avatar_url: { type: keyword }"`
 	Roles     []UserRole  `json:"roles" elastic_mapping:"roles: { type: object }"`

--- a/modules/security/api/account.go
+++ b/modules/security/api/account.go
@@ -37,6 +37,7 @@ import (
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/util"
 	"net/http"
+	"strings"
 )
 
 const userInSession = "user_session:"
@@ -56,6 +57,49 @@ func (h APIHandler) Logout(w http.ResponseWriter, r *http.Request, ps httprouter
 	rbac.DeleteUserToken(reqUser.UserId)
 	h.WriteOKJSON(w, util.MapStr{
 		"status": "ok",
+	})
+}
+
+func (h APIHandler) LoginChallenge(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	var req struct {
+		Username string `json:"username"`
+		UserName string `json:"userName"`
+	}
+	err := h.DecodeJSON(r, &req)
+	if err != nil {
+		h.Error400(w, err.Error())
+		return
+	}
+
+	username := normalizedUsername(req.Username, req.UserName)
+	if username == "" {
+		h.Error400(w, "username is required")
+		return
+	}
+
+	user, err := h.User.GetBy("name", username)
+	if err != nil {
+		h.ErrorInternalServer(w, err.Error())
+		return
+	}
+
+	if user == nil || !rbac.CanUsePasswordChallenge(user) {
+		h.WriteOKJSON(w, util.MapStr{
+			"status": "ok",
+			"method": "plain",
+		})
+		return
+	}
+
+	challenge := rbac.NewLoginChallenge(username)
+	h.WriteOKJSON(w, util.MapStr{
+		"status":       "ok",
+		"method":       rbac.PasswordChallengeMethod,
+		"algorithm":    rbac.PasswordChallengeAlgorithm,
+		"iterations":   rbac.PasswordChallengeIterations,
+		"challenge_id": challenge.ID,
+		"nonce":        challenge.Nonce,
+		"salt":         user.PasswordSalt,
 	})
 }
 
@@ -128,12 +172,11 @@ func (h APIHandler) UpdatePassword(w http.ResponseWriter, r *http.Request, ps ht
 		h.ErrorInternalServer(w, "old password is not correct")
 		return
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
+	err = rbac.SetPassword(&user, req.NewPassword)
 	if err != nil {
 		h.ErrorInternalServer(w, err.Error())
 		return
 	}
-	user.Password = string(hash)
 	err = h.User.Update(&user)
 	if err != nil {
 		h.ErrorInternalServer(w, err.Error())
@@ -178,8 +221,11 @@ func (h APIHandler) UpdateProfile(w http.ResponseWriter, r *http.Request, ps htt
 
 func (h APIHandler) Login(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var req struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
+		Username    string `json:"username"`
+		UserName    string `json:"userName"`
+		Password    string `json:"password"`
+		ChallengeID string `json:"challenge_id"`
+		Proof       string `json:"proof"`
 	}
 	err := h.DecodeJSON(r, &req)
 	if err != nil {
@@ -188,9 +234,19 @@ func (h APIHandler) Login(w http.ResponseWriter, r *http.Request, ps httprouter.
 	}
 
 	var user *rbac.User
+	username := normalizedUsername(req.Username, req.UserName)
+	if username == "" {
+		h.Error400(w, "username is required")
+		return
+	}
 
 	//check user validation
-	ok, user, err := realm.Authenticate(req.Username, req.Password)
+	var ok bool
+	if req.ChallengeID != "" || req.Proof != "" {
+		ok, user, err = h.authenticateChallengeLogin(username, req.ChallengeID, req.Proof)
+	} else {
+		ok, user, err = realm.Authenticate(username, req.Password)
+	}
 	if err != nil {
 		h.WriteError(w, err.Error(), 500)
 		return
@@ -202,14 +258,20 @@ func (h APIHandler) Login(w http.ResponseWriter, r *http.Request, ps httprouter.
 	}
 
 	if user == nil {
-		h.ErrorInternalServer(w, fmt.Sprintf("failed to authenticate user: %v", req.Username))
+		h.ErrorInternalServer(w, fmt.Sprintf("failed to authenticate user: %v", username))
 		return
+	}
+
+	if user.AuthProvider == NativeProvider && req.Password != "" {
+		if err := h.ensurePasswordChallenge(user, req.Password); err != nil {
+			log.Warnf("failed to migrate password verifier for user [%s]: %v", username, err)
+		}
 	}
 
 	//check permissions
 	ok, err = realm.Authorize(user)
 	if err != nil || !ok {
-		h.ErrorInternalServer(w, fmt.Sprintf("failed to authorize user: %v", req.Username))
+		h.ErrorInternalServer(w, fmt.Sprintf("failed to authorize user: %v", username))
 		return
 	}
 
@@ -222,10 +284,56 @@ func (h APIHandler) Login(w http.ResponseWriter, r *http.Request, ps httprouter.
 	//generate access token
 	token, err := rbac.GenerateAccessToken(user)
 	if err != nil {
-		h.ErrorInternalServer(w, fmt.Sprintf("failed to authorize user: %v", req.Username))
+		h.ErrorInternalServer(w, fmt.Sprintf("failed to authorize user: %v", username))
 		return
 	}
 
 	//api.SetSession(w, r, userInSession+req.Username, req.Username)
 	h.WriteOKJSON(w, token)
+}
+
+func normalizedUsername(username, userName string) string {
+	username = strings.TrimSpace(username)
+	if username != "" {
+		return username
+	}
+	return strings.TrimSpace(userName)
+}
+
+func (h APIHandler) authenticateChallengeLogin(username, challengeID, proof string) (bool, *rbac.User, error) {
+	if challengeID == "" || proof == "" {
+		return false, nil, fmt.Errorf("challenge response is incomplete")
+	}
+
+	challenge, err := rbac.ConsumeLoginChallenge(challengeID, username)
+	if err != nil {
+		return false, nil, err
+	}
+
+	user, err := h.User.GetBy("name", username)
+	if err != nil {
+		return false, nil, err
+	}
+	if user == nil {
+		return false, nil, fmt.Errorf("invalid username or password")
+	}
+	if !rbac.CanUsePasswordChallenge(user) {
+		return false, nil, fmt.Errorf("password challenge is not available")
+	}
+	if !rbac.VerifyPasswordProof(user.PasswordVerifier, username, challenge.ID, challenge.Nonce, proof) {
+		return false, nil, fmt.Errorf("incorrect password")
+	}
+
+	user.AuthProvider = NativeProvider
+	return true, user, nil
+}
+
+func (h APIHandler) ensurePasswordChallenge(user *rbac.User, password string) error {
+	if user == nil || password == "" || rbac.CanUsePasswordChallenge(user) {
+		return nil
+	}
+	if err := rbac.EnsurePasswordChallenge(user, password); err != nil {
+		return err
+	}
+	return h.User.Update(user)
 }

--- a/modules/security/api/init.go
+++ b/modules/security/api/init.go
@@ -61,6 +61,7 @@ func Init() {
 	api.HandleAPIMethod(api.GET, "/user/_search", apiHandler.RequirePermission(apiHandler.SearchUser, enum.UserReadPermission...))
 	api.HandleAPIMethod(api.PUT, "/user/:id/password", apiHandler.RequirePermission(apiHandler.UpdateUserPassword, enum.UserAllPermission...))
 
+	api.HandleAPIMethod(api.POST, "/account/login/challenge", apiHandler.LoginChallenge)
 	api.HandleAPIMethod(api.POST, "/account/login", apiHandler.Login)
 	api.HandleAPIMethod(api.POST, "/account/logout", apiHandler.Logout)
 	api.HandleAPIMethod(api.DELETE, "/account/logout", apiHandler.Logout)

--- a/modules/security/api/user.go
+++ b/modules/security/api/user.go
@@ -32,7 +32,6 @@ import (
 	"errors"
 	"github.com/buger/jsonparser"
 	log "github.com/cihub/seelog"
-	"golang.org/x/crypto/bcrypt"
 	rbac "infini.sh/console/core/security"
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
@@ -64,11 +63,11 @@ func (h APIHandler) CreateUser(w http.ResponseWriter, r *http.Request, ps httpro
 		return
 	}
 	randStr := util.GenerateSecureString(16)
-	hash, err := bcrypt.GenerateFromPassword([]byte(randStr), bcrypt.DefaultCost)
+	err = rbac.SetPassword(&user, randStr)
 	if err != nil {
+		h.ErrorInternalServer(w, err.Error())
 		return
 	}
-	user.Password = string(hash)
 
 	now := time.Now()
 	user.Created = &now
@@ -117,6 +116,9 @@ func (h APIHandler) GetUser(w http.ResponseWriter, r *http.Request, ps httproute
 		h.ErrorInternalServer(w, err.Error())
 		return
 	}
+	user.Password = ""
+	user.PasswordSalt = ""
+	user.PasswordVerifier = ""
 	h.WriteOKJSON(w, api.FoundResponse(id, user))
 	return
 }
@@ -150,6 +152,9 @@ func (h APIHandler) UpdateUser(w http.ResponseWriter, r *http.Request, ps httpro
 	user.Updated = &now
 	user.Created = oldUser.Created
 	user.ID = id
+	user.Password = oldUser.Password
+	user.PasswordSalt = oldUser.PasswordSalt
+	user.PasswordVerifier = oldUser.PasswordVerifier
 	err = h.User.Update(&user)
 
 	if err != nil {
@@ -217,6 +222,8 @@ func (h APIHandler) SearchUser(w http.ResponseWriter, r *http.Request, ps httpro
 	hitsBuf.Write([]byte("["))
 	jsonparser.ArrayEach(res.Raw, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		value = jsonparser.Delete(value, "_source", "password")
+		value = jsonparser.Delete(value, "_source", "password_salt")
+		value = jsonparser.Delete(value, "_source", "password_verifier")
 		hitsBuf.Write(value)
 		hitsBuf.Write([]byte(","))
 	}, "hits", "hits")
@@ -261,11 +268,11 @@ func (h APIHandler) UpdateUserPassword(w http.ResponseWriter, r *http.Request, p
 		h.ErrorInternalServer(w, err.Error())
 		return
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	err = rbac.SetPassword(&user, req.Password)
 	if err != nil {
+		h.ErrorInternalServer(w, err.Error())
 		return
 	}
-	user.Password = string(hash)
 	//t:=time.Now()
 	//user.Updated =&t
 	err = h.User.Update(&user)

--- a/web/src/models/login.js
+++ b/web/src/models/login.js
@@ -1,11 +1,16 @@
 import { routerRedux } from "dva/router";
 import { stringify } from "qs";
-import { fakeAccountLogin, getFakeCaptcha } from "@/services/api";
+import {
+  fakeAccountLogin,
+  getAccountLoginChallenge,
+  getFakeCaptcha,
+} from "@/services/api";
 import { setAuthority } from "@/utils/authority";
 import { getPageQuery } from "@/utils/utils";
 import { reloadAuthorized } from "@/utils/Authorized";
 import * as CurrentUser from "@/utils/CurrentUser";
 import { getAuthEnabled } from "@/utils/authority";
+import { buildPasswordProof } from "@/utils/password";
 
 export default {
   namespace: "login",
@@ -16,7 +21,28 @@ export default {
 
   effects: {
     *login({ payload }, { call, put }) {
-      const response = yield call(fakeAccountLogin, payload);
+      const username = payload.username || payload.userName;
+      let loginPayload = payload;
+      const challenge = yield call(getAccountLoginChallenge, { username });
+
+      if (challenge?.status === "ok" && challenge?.method === "challenge") {
+        const proof = yield call(buildPasswordProof, {
+          password: payload.password,
+          username,
+          challengeId: challenge.challenge_id,
+          nonce: challenge.nonce,
+          salt: challenge.salt,
+          iterations: challenge.iterations,
+        });
+        loginPayload = {
+          userName: username,
+          type: payload.type,
+          challenge_id: challenge.challenge_id,
+          proof,
+        };
+      }
+
+      const response = yield call(fakeAccountLogin, loginPayload);
       yield put({
         type: "changeLoginStatus",
         payload: response,

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -114,6 +114,18 @@ export async function fakeAccountLogin(params) {
   });
 }
 
+export async function getAccountLoginChallenge(params) {
+  return request(
+    "/account/login/challenge",
+    {
+      method: "POST",
+      body: params,
+    },
+    false,
+    false
+  );
+}
+
 export async function fakeRegister(params) {
   return request("/api/register", {
     method: "POST",

--- a/web/src/utils/password.js
+++ b/web/src/utils/password.js
@@ -1,0 +1,68 @@
+const encoder = new TextEncoder();
+
+const toHex = (buffer) =>
+  Array.from(buffer)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+const fromHex = (hex) => {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+};
+
+async function derivePasswordVerifier(password, salt, iterations) {
+  if (!window.crypto?.subtle) {
+    throw new Error("Web Crypto API unavailable");
+  }
+
+  const passwordKey = await window.crypto.subtle.importKey(
+    "raw",
+    encoder.encode(password),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
+  const bits = await window.crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      salt: encoder.encode(salt),
+      iterations,
+      hash: "SHA-256",
+    },
+    passwordKey,
+    256
+  );
+
+  return toHex(new Uint8Array(bits));
+}
+
+export async function buildPasswordProof({
+  password,
+  username,
+  challengeId,
+  nonce,
+  salt,
+  iterations,
+}) {
+  const verifier = await derivePasswordVerifier(password, salt, iterations);
+  const hmacKey = await window.crypto.subtle.importKey(
+    "raw",
+    fromHex(verifier),
+    {
+      name: "HMAC",
+      hash: "SHA-256",
+    },
+    false,
+    ["sign"]
+  );
+  const signature = await window.crypto.subtle.sign(
+    "HMAC",
+    hmacKey,
+    encoder.encode(`${username}:${challengeId}:${nonce}`)
+  );
+
+  return toHex(new Uint8Array(signature));
+}


### PR DESCRIPTION
## Summary
- add native password challenge generation and proof verification with persisted salt and verifier fields
- update user password flows to maintain password challenge data without exposing it in user APIs
- request a login challenge in the web client and submit a derived proof instead of the raw password when challenge login is available

## Testing
- go test ./core/security ./modules/security/api
- NODE_OPTIONS="--openssl-legacy-provider --max_old_space_size=4096" ./node_modules/.bin/umi build