### PR TITLE
fix: redirect login to setup initialization

### DIFF
--- a/web/src/pages/User/Login.js
+++ b/web/src/pages/User/Login.js
@@ -3,7 +3,10 @@ import { connect } from "dva";
 import { formatMessage, FormattedMessage } from "umi/locale";
 import Link from "umi/link";
 import { Checkbox, Alert, Icon,Button } from "antd";
+import router from "umi/router";
 import Login from "@/components/Login";
+import { getHealth } from "@/services/system";
+import { getSetupRequired, setSetupRequired } from "@/utils/setup";
 import styles from "./Login.less";
 import "./LoginPage.scss";
 
@@ -17,6 +20,27 @@ class LoginPage extends Component {
   state = {
     type: "account",
     autoLogin: true,
+  };
+
+  componentDidMount() {
+    if (getSetupRequired() === "true") {
+      router.replace("/guide/initialization");
+      return;
+    }
+
+    this.syncSetupState();
+  }
+
+  syncSetupState = async () => {
+    try {
+      const res = await getHealth();
+      setSetupRequired(`${!!res?.setup_required}`);
+      if (res?.setup_required) {
+        router.replace("/guide/initialization");
+      }
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   onTabChange = (type) => {


### PR DESCRIPTION
## Summary
- check the cached setup-required state when the login page mounts
- refresh the setup-required status from the health API before rendering the login flow
- redirect directly to `/guide/initialization` whenever setup is still required

## Testing
- NODE_OPTIONS="--openssl-legacy-provider --max_old_space_size=4096" ./node_modules/.bin/umi build