### PR TITLE
fix: validate email channels before enabling

### DIFF
--- a/plugin/api/alerting/channel.go
+++ b/plugin/api/alerting/channel.go
@@ -353,6 +353,12 @@ func (alertAPI *AlertAPI) batchEnableChannel(w http.ResponseWriter, req *http.Re
 		return
 	}
 	if len(channelIDs) > 0 {
+		err = validateChannelsBeforeEnable(channelIDs)
+		if err != nil {
+			log.Error(err)
+			alertAPI.WriteError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		err = setChannelEnabled(true, channelIDs)
 		if err != nil {
 			log.Error(err)
@@ -399,4 +405,52 @@ func setChannelEnabled(enabled bool, channelIDs []string) error {
 	}
 	err := orm.UpdateBy(alerting.Channel{}, util.MustToJSONBytes(q))
 	return err
+}
+
+func validateChannelsBeforeEnable(channelIDs []string) error {
+	for _, id := range channelIDs {
+		channel := alerting.Channel{}
+		channel.ID = id
+		exists, err := orm.Get(&channel)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("channel [%s] not found", id)
+		}
+		if err = validateChannelBeforeEnable(&channel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateChannelBeforeEnable(channel *alerting.Channel) error {
+	if channel == nil {
+		return fmt.Errorf("empty channel")
+	}
+
+	channelType := channel.SubType
+	if channelType == "" {
+		channelType = channel.Type
+	}
+	if channelType != alerting.ChannelEmail {
+		return nil
+	}
+
+	if channel.Email == nil {
+		return fmt.Errorf("email channel [%s] is incomplete, please configure the smtp server and recipients first", channel.Name)
+	}
+
+	if channel.Email.ServerID == "" && len(channel.Email.Recipients.To) == 0 {
+		return fmt.Errorf("email channel [%s] is incomplete, please configure the smtp server and recipients first", channel.Name)
+	}
+	if channel.Email.ServerID == "" {
+		return fmt.Errorf("email channel [%s] is incomplete, please configure the smtp server first", channel.Name)
+	}
+	if len(channel.Email.Recipients.To) == 0 {
+		return fmt.Errorf("email channel [%s] is incomplete, please configure at least one recipient first", channel.Name)
+	}
+
+	return nil
 }

--- a/plugin/api/alerting/channel_test.go
+++ b/plugin/api/alerting/channel_test.go
@@ -1,0 +1,59 @@
+package alerting
+
+import (
+	"strings"
+	"testing"
+
+	modelalerting "infini.sh/console/model/alerting"
+)
+
+func TestValidateChannelBeforeEnableRequiresEmailConfig(t *testing.T) {
+	channel := &modelalerting.Channel{
+		Name:    "Email Channel",
+		Type:    modelalerting.ChannelEmail,
+		SubType: modelalerting.ChannelEmail,
+	}
+
+	err := validateChannelBeforeEnable(channel)
+	if err == nil {
+		t.Fatal("expected incomplete email channel to be rejected")
+	}
+	if !strings.Contains(err.Error(), "smtp server and recipients") {
+		t.Fatalf("expected combined config hint, got %v", err)
+	}
+}
+
+func TestValidateChannelBeforeEnableRequiresRecipients(t *testing.T) {
+	channel := &modelalerting.Channel{
+		Name:    "Email Channel",
+		Type:    modelalerting.ChannelEmail,
+		SubType: modelalerting.ChannelEmail,
+		Email: &modelalerting.Email{
+			ServerID: "smtp-1",
+		},
+	}
+
+	err := validateChannelBeforeEnable(channel)
+	if err == nil {
+		t.Fatal("expected missing recipients to be rejected")
+	}
+	if !strings.Contains(err.Error(), "at least one recipient") {
+		t.Fatalf("expected recipient hint, got %v", err)
+	}
+}
+
+func TestValidateChannelBeforeEnableAcceptsCompleteEmailChannel(t *testing.T) {
+	channel := &modelalerting.Channel{
+		Name:    "Email Channel",
+		Type:    modelalerting.ChannelEmail,
+		SubType: modelalerting.ChannelEmail,
+		Email: &modelalerting.Email{
+			ServerID: "smtp-1",
+		},
+	}
+	channel.Email.Recipients.To = []string{"ops@example.com"}
+
+	if err := validateChannelBeforeEnable(channel); err != nil {
+		t.Fatalf("expected complete email channel to pass validation, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- validate email channels before bulk enable requests are applied
- block incomplete email channel configs that are missing an SMTP server, recipients, or both
- return a bad request instead of enabling channels that still cannot send alerts

## Testing
- go test ./plugin/api/alerting