### PR TITLE
fix: prevent concurrent setup initialization

### DIFF
--- a/plugin/setup/setup.go
+++ b/plugin/setup/setup.go
@@ -37,6 +37,8 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"infini.sh/console/core/security"
@@ -100,15 +102,27 @@ func (module *Module) Setup() {
 }
 
 var setupFinishedCallback = []func(){}
+var setupCallbackOnce sync.Once
+var setupInitializeRunning uint32
 
 func RegisterSetupCallback(f func()) {
 	setupFinishedCallback = append(setupFinishedCallback, f)
 }
 
 func InvokeSetupCallback() {
-	for _, v := range setupFinishedCallback {
-		v()
-	}
+	setupCallbackOnce.Do(func() {
+		for _, v := range setupFinishedCallback {
+			v()
+		}
+	})
+}
+
+func acquireSetupInitialization() bool {
+	return atomic.CompareAndSwapUint32(&setupInitializeRunning, 0, 1)
+}
+
+func releaseSetupInitialization() {
+	atomic.StoreUint32(&setupInitializeRunning, 0)
 }
 
 // Start initializes the module and registers a change event for credentials.
@@ -400,6 +414,11 @@ func (module *Module) initialize(w http.ResponseWriter, r *http.Request, ps http
 		module.WriteError(w, "setup not permitted", http.StatusInternalServerError)
 		return
 	}
+	if !acquireSetupInitialization() {
+		module.WriteError(w, "setup is already running", http.StatusConflict)
+		return
+	}
+	defer releaseSetupInitialization()
 	request := &SetupRequest{}
 	err := module.DecodeJSON(r, request)
 	if err != nil {

--- a/plugin/setup/setup_test.go
+++ b/plugin/setup/setup_test.go
@@ -1,0 +1,74 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package task
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestInvokeSetupCallbackRunsOnlyOnce(t *testing.T) {
+	previousCallbacks := setupFinishedCallback
+	previousOnce := setupCallbackOnce
+	defer func() {
+		setupFinishedCallback = previousCallbacks
+		setupCallbackOnce = previousOnce
+	}()
+
+	setupFinishedCallback = nil
+	setupCallbackOnce = sync.Once{}
+
+	count := 0
+	RegisterSetupCallback(func() {
+		count++
+	})
+	RegisterSetupCallback(func() {
+		count++
+	})
+
+	InvokeSetupCallback()
+	InvokeSetupCallback()
+
+	if count != 2 {
+		t.Fatalf("expected callbacks to run once each, got %d invocations", count)
+	}
+}
+
+func TestAcquireSetupInitialization(t *testing.T) {
+	releaseSetupInitialization()
+	defer releaseSetupInitialization()
+
+	if !acquireSetupInitialization() {
+		t.Fatal("expected first acquire to succeed")
+	}
+	if acquireSetupInitialization() {
+		t.Fatal("expected second acquire to fail while initialization is running")
+	}
+
+	releaseSetupInitialization()
+
+	if !acquireSetupInitialization() {
+		t.Fatal("expected acquire to succeed after release")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure setup callbacks only run once even if setup completion is triggered repeatedly
- reject concurrent `/setup/_initialize` requests while one initialization is already running
- clear the initialization guard when setup exits so later retries can proceed normally

## Testing
- go test ./plugin/setup