### PR TITLE
fix: fall back when route locale is missing

### DIFF
--- a/web/src/layouts/BasicLayout.js
+++ b/web/src/layouts/BasicLayout.js
@@ -69,7 +69,7 @@ const { Content } = Layout;
 function formatter(data, parentAuthority, parentName) {
   return data
     .map((item) => {
-      let locale = "menu";
+      let locale;
       if (parentName && item.name) {
         locale = `${parentName}.${item.name}`;
       } else if (item.name) {
@@ -290,8 +290,12 @@ class BasicLayout extends React.PureComponent {
     if (!currRouterData) {
       return APP_TITLE;
     }
+    const messageId = currRouterData.locale || currRouterData.name;
+    if (!messageId) {
+      return APP_TITLE;
+    }
     const message = formatMessage({
-      id: currRouterData.locale || currRouterData.name,
+      id: messageId,
       defaultMessage: currRouterData.name,
     });
     return `${message} - ${APP_TITLE}`;


### PR DESCRIPTION
## Summary
- stop seeding route locale ids with a default `menu` prefix when a route has no name
- skip page-title formatting when the matched route has neither a locale id nor a name
- avoid broken titles for routes that are intentionally missing menu metadata

## Testing
- NODE_OPTIONS="--openssl-legacy-provider --max_old_space_size=4096" ./node_modules/.bin/umi build