### PR TITLE
feat: add system settings page for rollup retention

### DIFF
--- a/plugin/api/init.go
+++ b/plugin/api/init.go
@@ -36,6 +36,7 @@ import (
 	"infini.sh/console/plugin/api/layout"
 	"infini.sh/console/plugin/api/notification"
 	"infini.sh/console/plugin/api/platform"
+	"infini.sh/console/plugin/api/settings"
 	"infini.sh/framework/core/api"
 )
 
@@ -80,4 +81,5 @@ func Init(cfg *config.AppConfig) {
 	email.InitAPI()
 	data.InitAPI()
 	platform.InitAPI()
+	settings.InitAPI()
 }

--- a/plugin/api/settings/api.go
+++ b/plugin/api/settings/api.go
@@ -1,0 +1,1218 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	log "github.com/cihub/seelog"
+	"infini.sh/console/core"
+	"infini.sh/console/core/security/enum"
+	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/elastic"
+	"infini.sh/framework/core/env"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/util"
+	elasticCommon "infini.sh/framework/modules/elastic/common"
+)
+
+type SettingsAPI struct {
+	core.Handler
+}
+
+type rawRequester interface {
+	Request(ctx context.Context, method, url string, body []byte) (*util.Result, error)
+}
+
+type rollupSettingsRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+type retentionSettingsRequest struct {
+	Days    int    `json:"days"`
+	MaxSize string `json:"max_size"`
+}
+
+const defaultRetentionDays = 30
+const defaultRetentionMaxSize = "50gb"
+
+var retentionPolicyPattern = regexp.MustCompile(`-(\d+)days-retention$`)
+var retentionSizePattern = regexp.MustCompile(`(?i)^(\d+)([kmgt]b?|b)$`)
+
+func InitAPI() {
+	handler := SettingsAPI{}
+	api.HandleAPIMethod(api.GET, "/setting/system/retention", handler.RequirePermission(handler.getRetentionSetting, enum.PermissionElasticsearchClusterRead))
+	api.HandleAPIMethod(api.PUT, "/setting/system/retention", handler.RequirePermission(handler.updateRetentionSetting, enum.PermissionElasticsearchClusterWrite))
+	api.HandleAPIMethod(api.GET, "/setting/system/rollup", handler.RequirePermission(handler.getRollupSetting, enum.PermissionElasticsearchClusterRead))
+	api.HandleAPIMethod(api.PUT, "/setting/system/rollup", handler.RequirePermission(handler.updateRollupSetting, enum.PermissionElasticsearchClusterWrite))
+}
+
+func resolveSystemIndexPrefix() string {
+	ormConfig := elasticCommon.ORMConfig{}
+	_, err := env.ParseConfig("elastic.orm", &ormConfig)
+	if err != nil {
+		log.Warn(err)
+	}
+	indexPrefix := strings.TrimSpace(ormConfig.IndexPrefix)
+	if indexPrefix == "" {
+		indexPrefix = ".infini_"
+	}
+	return indexPrefix
+}
+
+func getMetricsRetentionPolicyID(indexPrefix string, days int) string {
+	return fmt.Sprintf("ilm_%smetrics-%ddays-retention", indexPrefix, days)
+}
+
+func getRollupRetentionPolicyID(indexPrefix string, days int) string {
+	return fmt.Sprintf("ilm_%srollup-%ddays-retention", indexPrefix, days)
+}
+
+func getManagedRetentionTemplateNames(indexPrefix string) []string {
+	return []string{
+		indexPrefix + "metrics-rollover",
+		indexPrefix + "logs-rollover",
+		indexPrefix + "requests_logging-rollover",
+		indexPrefix + "async_bulk_results-rollover",
+		indexPrefix + "alert-history-rollover",
+		indexPrefix + "activities-rollover",
+	}
+}
+
+func getManagedRetentionIndexPatterns(indexPrefix string) []string {
+	return []string{
+		indexPrefix + "metrics*",
+		indexPrefix + "logs*",
+		indexPrefix + "requests_logging*",
+		indexPrefix + "async_bulk_results*",
+		indexPrefix + "alert-history*",
+		indexPrefix + "activities*",
+	}
+}
+
+func castMap(value interface{}) (map[string]interface{}, bool) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return v, true
+	case util.MapStr:
+		return v, true
+	default:
+		return nil, false
+	}
+}
+
+func castSlice(value interface{}) ([]interface{}, bool) {
+	items, ok := value.([]interface{})
+	return items, ok
+}
+
+func parseRetentionDays(value interface{}) (int, error) {
+	if value == nil {
+		return 0, fmt.Errorf("retention value is empty")
+	}
+	rawValue := strings.TrimSpace(fmt.Sprint(value))
+	if rawValue == "" || rawValue == "<nil>" {
+		return 0, fmt.Errorf("retention value is empty")
+	}
+	rawValue = strings.TrimSuffix(rawValue, "d")
+	days, err := strconv.Atoi(rawValue)
+	if err != nil || days <= 0 {
+		return 0, fmt.Errorf("invalid retention value: %v", value)
+	}
+	return days, nil
+}
+
+func parseRetentionDaysFromPolicyID(policyID string) (int, error) {
+	matches := retentionPolicyPattern.FindStringSubmatch(strings.TrimSpace(policyID))
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("retention days not found in policy id: %s", policyID)
+	}
+	return parseRetentionDays(matches[1])
+}
+
+func normalizeRetentionSize(value interface{}) (string, error) {
+	rawValue := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(fmt.Sprint(value)), " ", ""))
+	if rawValue == "" || rawValue == "<nil>" {
+		return "", fmt.Errorf("retention size is empty")
+	}
+	if _, err := util.ToBytes(rawValue); err != nil {
+		return "", err
+	}
+	matches := retentionSizePattern.FindStringSubmatch(rawValue)
+	if len(matches) != 3 {
+		return "", fmt.Errorf("invalid retention size: %v", value)
+	}
+	unit := strings.ToLower(matches[2])
+	switch unit {
+	case "k":
+		unit = "kb"
+	case "m":
+		unit = "mb"
+	case "g":
+		unit = "gb"
+	case "t":
+		unit = "tb"
+	}
+	return matches[1] + unit, nil
+}
+
+func rawJSONRequest(requester rawRequester, cfg *elastic.ElasticsearchConfig, method, path string, payload interface{}) (map[string]interface{}, int, error) {
+	var body []byte
+	if payload != nil {
+		body = util.MustToJSONBytes(payload)
+	}
+	requestURL := fmt.Sprintf("%s%s", strings.TrimRight(cfg.GetAnyEndpoint(), "/"), path)
+	resp, err := requester.Request(context.Background(), method, requestURL, body)
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, resp.StatusCode, nil
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, resp.StatusCode, fmt.Errorf("%s", resp.Body)
+	}
+	if len(resp.Body) == 0 {
+		return map[string]interface{}{}, resp.StatusCode, nil
+	}
+	result := map[string]interface{}{}
+	if err := util.FromJSONBytes(resp.Body, &result); err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return result, resp.StatusCode, nil
+}
+
+func getLegacyTemplate(requester rawRequester, cfg *elastic.ElasticsearchConfig, templateName string) (map[string]interface{}, int, error) {
+	response, statusCode, err := rawJSONRequest(requester, cfg, util.Verb_GET, "/_template/"+templateName, nil)
+	if err != nil || statusCode == http.StatusNotFound {
+		return nil, statusCode, err
+	}
+	template, ok := castMap(response[templateName])
+	if !ok {
+		return nil, statusCode, fmt.Errorf("template %s payload not found", templateName)
+	}
+	return template, statusCode, nil
+}
+
+func putLegacyTemplate(requester rawRequester, cfg *elastic.ElasticsearchConfig, templateName string, template map[string]interface{}) error {
+	_, _, err := rawJSONRequest(requester, cfg, util.Verb_PUT, "/_template/"+templateName, template)
+	return err
+}
+
+func readTemplateLifecyclePolicyID(template map[string]interface{}) (string, error) {
+	settings, ok := castMap(template["settings"])
+	if !ok {
+		return "", fmt.Errorf("template settings not found")
+	}
+	if policyID, ok := settings["index.lifecycle.name"]; ok {
+		value := strings.TrimSpace(fmt.Sprint(policyID))
+		if value != "" && value != "<nil>" {
+			return value, nil
+		}
+	}
+	if indexSettings, ok := castMap(settings["index"]); ok {
+		if lifecycle, ok := castMap(indexSettings["lifecycle"]); ok {
+			value := strings.TrimSpace(fmt.Sprint(lifecycle["name"]))
+			if value != "" && value != "<nil>" {
+				return value, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("template lifecycle policy not found")
+}
+
+func setTemplateLifecyclePolicyID(template map[string]interface{}, policyID string) error {
+	settings, ok := castMap(template["settings"])
+	if !ok {
+		return fmt.Errorf("template settings not found")
+	}
+	updated := false
+	if _, exists := settings["index.lifecycle.name"]; exists {
+		settings["index.lifecycle.name"] = policyID
+		updated = true
+	}
+	if indexSettings, ok := castMap(settings["index"]); ok {
+		if lifecycle, ok := castMap(indexSettings["lifecycle"]); ok {
+			lifecycle["name"] = policyID
+			updated = true
+		}
+	}
+	if !updated {
+		return fmt.Errorf("template lifecycle policy not found")
+	}
+	return nil
+}
+
+func getILMPolicy(requester rawRequester, cfg *elastic.ElasticsearchConfig, policyID string) (map[string]interface{}, int64, int64, int, error) {
+	response, statusCode, err := rawJSONRequest(
+		requester,
+		cfg,
+		util.Verb_GET,
+		"/_ilm/policy/"+url.PathEscape(policyID),
+		nil,
+	)
+	if err != nil || statusCode == http.StatusNotFound {
+		return nil, 0, 0, statusCode, err
+	}
+	seqNo, _ := response["_seq_no"].(json.Number)
+	primaryTerm, _ := response["_primary_term"].(json.Number)
+	seqNoVal, _ := seqNo.Int64()
+	primaryTermVal, _ := primaryTerm.Int64()
+
+	policy, err := extractILMPolicy(response, policyID)
+	return policy, seqNoVal, primaryTermVal, statusCode, err
+}
+
+func extractILMPolicy(response map[string]interface{}, policyID string) (map[string]interface{}, error) {
+	if policyWrapper, ok := castMap(response[policyID]); ok {
+		if policy, ok := castMap(policyWrapper["policy"]); ok {
+			return policy, nil
+		}
+		return nil, fmt.Errorf("ilm policy body not found")
+	}
+
+	if policy, ok := castMap(response["policy"]); ok {
+		return policy, nil
+	}
+
+	if len(response) == 1 {
+		for _, value := range response {
+			if policyWrapper, ok := castMap(value); ok {
+				if policy, ok := castMap(policyWrapper["policy"]); ok {
+					return policy, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("ilm policy payload not found")
+}
+
+func normalizeILMActionForPut(actionName string, rawConfig interface{}) (string, interface{}, bool) {
+	switch actionName {
+	case "retry", "timeout":
+		return "", nil, false
+	}
+
+	config, ok := castMap(rawConfig)
+	if !ok {
+		if rawConfig == nil {
+			return actionName, util.MapStr{}, true
+		}
+		return actionName, rawConfig, true
+	}
+
+	normalized := util.MapStr{}
+	for key, value := range config {
+		normalized[key] = value
+	}
+
+	switch actionName {
+	case "rollover":
+		if value, exists := normalized["min_index_age"]; exists {
+			if _, hasMaxAge := normalized["max_age"]; !hasMaxAge {
+				normalized["max_age"] = value
+			}
+			delete(normalized, "min_index_age")
+		}
+		if value, exists := normalized["min_size"]; exists {
+			if _, hasMaxSize := normalized["max_size"]; !hasMaxSize {
+				normalized["max_size"] = value
+			}
+			delete(normalized, "min_size")
+		}
+		if value, exists := normalized["min_doc_count"]; exists {
+			if _, hasMaxDocs := normalized["max_docs"]; !hasMaxDocs {
+				normalized["max_docs"] = value
+			}
+			delete(normalized, "min_doc_count")
+		}
+	case "index_priority":
+		actionName = "set_priority"
+	case "allocation":
+		actionName = "allocate"
+		delete(normalized, "wait_for")
+	case "force_merge":
+		actionName = "forcemerge"
+	case "read_only":
+		actionName = "readonly"
+	}
+
+	return actionName, normalized, true
+}
+
+func normalizeILMPolicyForPut(policy map[string]interface{}) (map[string]interface{}, error) {
+	if phases, ok := castMap(policy["phases"]); ok {
+		return util.MapStr{
+			"phases": phases,
+		}, nil
+	}
+
+	states, ok := castSlice(policy["states"])
+	if !ok {
+		return nil, fmt.Errorf("ilm phases not found")
+	}
+
+	phaseMinAge := map[string]interface{}{
+		"hot": "0ms",
+	}
+	phaseBodies := util.MapStr{}
+
+	for _, stateValue := range states {
+		state, ok := castMap(stateValue)
+		if !ok {
+			continue
+		}
+
+		stateName := strings.TrimSpace(fmt.Sprint(state["name"]))
+		if stateName == "" || stateName == "<nil>" {
+			continue
+		}
+
+		if transitions, ok := castSlice(state["transitions"]); ok {
+			for _, transitionValue := range transitions {
+				transition, ok := castMap(transitionValue)
+				if !ok {
+					continue
+				}
+				targetState := strings.TrimSpace(fmt.Sprint(transition["state_name"]))
+				if targetState == "" || targetState == "<nil>" {
+					continue
+				}
+				if conditions, ok := castMap(transition["conditions"]); ok {
+					if minIndexAge, exists := conditions["min_index_age"]; exists {
+						phaseMinAge[targetState] = minIndexAge
+					}
+				}
+			}
+		}
+
+		phase := util.MapStr{}
+		if minAge, exists := phaseMinAge[stateName]; exists {
+			phase["min_age"] = minAge
+		}
+
+		phaseActions := util.MapStr{}
+		if actions, ok := castSlice(state["actions"]); ok {
+			for _, actionValue := range actions {
+				action, ok := castMap(actionValue)
+				if !ok {
+					continue
+				}
+				for actionName, actionConfig := range action {
+					normalizedName, normalizedConfig, shouldInclude := normalizeILMActionForPut(actionName, actionConfig)
+					if !shouldInclude {
+						continue
+					}
+					phaseActions[normalizedName] = normalizedConfig
+				}
+			}
+		}
+		if len(phaseActions) > 0 {
+			phase["actions"] = phaseActions
+		}
+
+		phaseBodies[stateName] = phase
+	}
+
+	if len(phaseBodies) == 0 {
+		return nil, fmt.Errorf("ilm phases not found")
+	}
+
+	for phaseName, minAge := range phaseMinAge {
+		if phase, ok := castMap(phaseBodies[phaseName]); ok {
+			if _, exists := phase["min_age"]; !exists {
+				phase["min_age"] = minAge
+			}
+		}
+	}
+
+	return util.MapStr{
+		"phases": phaseBodies,
+	}, nil
+}
+
+func putILMPolicy(requester rawRequester, cfg *elastic.ElasticsearchConfig, policyID string, policy map[string]interface{}, seqNo, primaryTerm int64) error {
+	normalizedPolicy, err := normalizeILMPolicyForPut(policy)
+	if err != nil {
+		return err
+	}
+	path := "/_ilm/policy/" + url.PathEscape(policyID)
+	if seqNo >= 0 {
+		path += fmt.Sprintf("?if_seq_no=%d&if_primary_term=%d", seqNo, primaryTerm)
+	}
+	_, _, err = rawJSONRequest(
+		requester,
+		cfg,
+		util.Verb_PUT,
+		path,
+		util.MapStr{"policy": normalizedPolicy},
+	)
+	return err
+}
+
+func deleteILMPolicy(requester rawRequester, cfg *elastic.ElasticsearchConfig, policyID string) error {
+	_, _, err := rawJSONRequest(
+		requester,
+		cfg,
+		util.Verb_DELETE,
+		"/_ilm/policy/"+url.PathEscape(policyID),
+		nil,
+	)
+	return err
+}
+
+func getILMRetentionDays(policy map[string]interface{}) (int, error) {
+	phases, ok := castMap(policy["phases"])
+	if ok {
+		if deletePhase, ok := castMap(phases["delete"]); ok {
+			if days, err := parseRetentionDays(deletePhase["min_age"]); err == nil {
+				return days, nil
+			}
+		}
+		if hotPhase, ok := castMap(phases["hot"]); ok {
+			if actions, ok := castMap(hotPhase["actions"]); ok {
+				if rollover, ok := castMap(actions["rollover"]); ok {
+					return parseRetentionDays(rollover["max_age"])
+				}
+			}
+		}
+	}
+	if _, ok := castSlice(policy["states"]); ok {
+		return getISMRetentionDays(policy)
+	}
+	return 0, fmt.Errorf("ilm phases not found")
+}
+
+func getILMRetentionMaxSize(policy map[string]interface{}) (string, error) {
+	phases, ok := castMap(policy["phases"])
+	if ok {
+		if hotPhase, ok := castMap(phases["hot"]); ok {
+			if actions, ok := castMap(hotPhase["actions"]); ok {
+				if rollover, ok := castMap(actions["rollover"]); ok {
+					return normalizeRetentionSize(rollover["max_size"])
+				}
+			}
+		}
+	}
+	if _, ok := castSlice(policy["states"]); ok {
+		return getISMRetentionMaxSize(policy)
+	}
+	return "", fmt.Errorf("ilm rollover max_size not found")
+}
+
+func setILMRetentionDays(policy map[string]interface{}, days int) error {
+	phases, ok := castMap(policy["phases"])
+	if ok {
+		retention := fmt.Sprintf("%dd", days)
+		updated := false
+		if hotPhase, ok := castMap(phases["hot"]); ok {
+			if actions, ok := castMap(hotPhase["actions"]); ok {
+				if rollover, ok := castMap(actions["rollover"]); ok {
+					rollover["max_age"] = retention
+					updated = true
+				}
+			}
+		}
+		if deletePhase, ok := castMap(phases["delete"]); ok {
+			deletePhase["min_age"] = retention
+			updated = true
+		}
+		if !updated {
+			return fmt.Errorf("ilm retention settings not found")
+		}
+		return nil
+	}
+	if _, ok := castSlice(policy["states"]); ok {
+		return setISMRetentionDays(policy, days)
+	}
+	return fmt.Errorf("ilm phases not found")
+}
+
+func setILMRetentionMaxSize(policy map[string]interface{}, size string) error {
+	normalizedSize, err := normalizeRetentionSize(size)
+	if err != nil {
+		return err
+	}
+	phases, ok := castMap(policy["phases"])
+	if ok {
+		if hotPhase, ok := castMap(phases["hot"]); ok {
+			if actions, ok := castMap(hotPhase["actions"]); ok {
+				if rollover, ok := castMap(actions["rollover"]); ok {
+					rollover["max_size"] = normalizedSize
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("ilm rollover settings not found")
+	}
+	if _, ok := castSlice(policy["states"]); ok {
+		return setISMRetentionMaxSize(policy, normalizedSize)
+	}
+	return fmt.Errorf("ilm phases not found")
+}
+
+func setRollupILMRetentionDays(policy map[string]interface{}, days int) error {
+	phases, ok := castMap(policy["phases"])
+	if ok {
+		deletePhase, ok := castMap(phases["delete"])
+		if !ok {
+			return fmt.Errorf("ilm delete phase not found")
+		}
+		retention := fmt.Sprintf("%dd", days)
+		deletePhase["min_age"] = retention
+		if actions, ok := castMap(deletePhase["actions"]); ok {
+			if deleteAction, ok := castMap(actions["delete"]); ok {
+				if _, exists := deleteAction["min_data_age"]; exists {
+					deleteAction["min_data_age"] = retention
+				}
+			}
+		}
+		return nil
+	}
+	states, ok := castSlice(policy["states"])
+	if !ok {
+		return fmt.Errorf("ilm phases not found")
+	}
+	retention := fmt.Sprintf("%dd", days)
+	updated := false
+	for _, stateValue := range states {
+		state, ok := castMap(stateValue)
+		if !ok {
+			continue
+		}
+		if transitions, ok := castSlice(state["transitions"]); ok {
+			for _, transitionValue := range transitions {
+				transition, ok := castMap(transitionValue)
+				if !ok {
+					continue
+				}
+				if conditions, ok := castMap(transition["conditions"]); ok {
+					if _, exists := conditions["min_index_age"]; exists {
+						conditions["min_index_age"] = retention
+						updated = true
+					}
+				}
+			}
+		}
+		if actions, ok := castSlice(state["actions"]); ok {
+			for _, actionValue := range actions {
+				action, ok := castMap(actionValue)
+				if !ok {
+					continue
+				}
+				if deleteAction, ok := castMap(action["delete"]); ok {
+					if _, exists := deleteAction["min_data_age"]; exists {
+						deleteAction["min_data_age"] = retention
+						updated = true
+					}
+				}
+			}
+		}
+	}
+	if !updated {
+		return fmt.Errorf("ilm retention settings not found")
+	}
+	return nil
+}
+
+func getISMRetentionDays(policy map[string]interface{}) (int, error) {
+	states, ok := castSlice(policy["states"])
+	if !ok {
+		return 0, fmt.Errorf("ism states not found")
+	}
+	for _, stateValue := range states {
+		state, ok := castMap(stateValue)
+		if !ok {
+			continue
+		}
+		if transitions, ok := castSlice(state["transitions"]); ok {
+			for _, transitionValue := range transitions {
+				transition, ok := castMap(transitionValue)
+				if !ok {
+					continue
+				}
+				if conditions, ok := castMap(transition["conditions"]); ok {
+					if days, err := parseRetentionDays(conditions["min_index_age"]); err == nil {
+						return days, nil
+					}
+				}
+			}
+		}
+		if actions, ok := castSlice(state["actions"]); ok {
+			for _, actionValue := range actions {
+				action, ok := castMap(actionValue)
+				if !ok {
+					continue
+				}
+				if rollover, ok := castMap(action["rollover"]); ok {
+					if days, err := parseRetentionDays(rollover["min_index_age"]); err == nil {
+						return days, nil
+					}
+				}
+			}
+		}
+	}
+	return 0, fmt.Errorf("ism retention days not found")
+}
+
+func getISMRetentionMaxSize(policy map[string]interface{}) (string, error) {
+	states, ok := castSlice(policy["states"])
+	if !ok {
+		return "", fmt.Errorf("ism states not found")
+	}
+	for _, stateValue := range states {
+		state, ok := castMap(stateValue)
+		if !ok {
+			continue
+		}
+		if actions, ok := castSlice(state["actions"]); ok {
+			for _, actionValue := range actions {
+				action, ok := castMap(actionValue)
+				if !ok {
+					continue
+				}
+				if rollover, ok := castMap(action["rollover"]); ok {
+					if size, err := normalizeRetentionSize(rollover["min_size"]); err == nil {
+						return size, nil
+					}
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("ism retention max size not found")
+}
+
+func setISMRetentionDays(policy map[string]interface{}, days int) error {
+	states, ok := castSlice(policy["states"])
+	if !ok {
+		return fmt.Errorf("ism states not found")
+	}
+	retention := fmt.Sprintf("%dd", days)
+	updated := false
+	for _, stateValue := range states {
+		state, ok := castMap(stateValue)
+		if !ok {
+			continue
+		}
+		if actions, ok := castSlice(state["actions"]); ok {
+			for _, actionValue := range actions {
+				action, ok := castMap(actionValue)
+				if !ok {
+					continue
+				}
+				if rollover, ok := castMap(action["rollover"]); ok {
+					rollover["min_index_age"] = retention
+					updated = true
+				}
+			}
+		}
+		if transitions, ok := castSlice(state["transitions"]); ok {
+			for _, transitionValue := range transitions {
+				transition, ok := castMap(transitionValue)
+				if !ok {
+					continue
+				}
+				if conditions, ok := castMap(transition["conditions"]); ok {
+					if _, exists := conditions["min_index_age"]; exists {
+						conditions["min_index_age"] = retention
+						updated = true
+					}
+				}
+			}
+		}
+	}
+	if !updated {
+		return fmt.Errorf("ism retention settings not found")
+	}
+	return nil
+}
+
+func setISMRetentionMaxSize(policy map[string]interface{}, size string) error {
+	normalizedSize, err := normalizeRetentionSize(size)
+	if err != nil {
+		return err
+	}
+	states, ok := castSlice(policy["states"])
+	if !ok {
+		return fmt.Errorf("ism states not found")
+	}
+	updated := false
+	for _, stateValue := range states {
+		state, ok := castMap(stateValue)
+		if !ok {
+			continue
+		}
+		if actions, ok := castSlice(state["actions"]); ok {
+			for _, actionValue := range actions {
+				action, ok := castMap(actionValue)
+				if !ok {
+					continue
+				}
+				if rollover, ok := castMap(action["rollover"]); ok {
+					rollover["min_size"] = normalizedSize
+					updated = true
+				}
+			}
+		}
+	}
+	if !updated {
+		return fmt.Errorf("ism rollover settings not found")
+	}
+	return nil
+}
+
+func getRetentionSettings(client elastic.API, cfg *elastic.ElasticsearchConfig) (int, string, error) {
+	requester, ok := client.(rawRequester)
+	if !ok {
+		return 0, "", fmt.Errorf("cluster client does not support raw requests")
+	}
+	indexPrefix := resolveSystemIndexPrefix()
+	if strings.EqualFold(cfg.Distribution, elastic.Opensearch) {
+		policyID := getMetricsRetentionPolicyID(indexPrefix, defaultRetentionDays)
+		response, statusCode, err := rawJSONRequest(
+			requester,
+			cfg,
+			util.Verb_GET,
+			"/_plugins/_ism/policies/"+url.PathEscape(policyID),
+			nil,
+		)
+		if err != nil {
+			return 0, "", err
+		}
+		if statusCode == http.StatusNotFound {
+			return defaultRetentionDays, defaultRetentionMaxSize, nil
+		}
+		policy, ok := castMap(response["policy"])
+		if !ok {
+			return 0, "", fmt.Errorf("ism policy payload not found")
+		}
+		days, err := getISMRetentionDays(policy)
+		if err != nil {
+			return 0, "", err
+		}
+		maxSize, err := getISMRetentionMaxSize(policy)
+		if err != nil {
+			maxSize = defaultRetentionMaxSize
+		}
+		return days, maxSize, nil
+	}
+
+	currentMetricsPolicyID := getMetricsRetentionPolicyID(indexPrefix, defaultRetentionDays)
+	template, statusCode, err := getLegacyTemplate(requester, cfg, indexPrefix+"metrics-rollover")
+	if err != nil {
+		return 0, "", err
+	}
+	currentDays := defaultRetentionDays
+	if statusCode == http.StatusNotFound {
+		return currentDays, defaultRetentionMaxSize, nil
+	}
+	if policyID, err := readTemplateLifecyclePolicyID(template); err == nil {
+		currentMetricsPolicyID = policyID
+		if days, parseErr := parseRetentionDaysFromPolicyID(policyID); parseErr == nil {
+			currentDays = days
+		}
+	}
+
+	policy, _, _, statusCode, err := getILMPolicy(requester, cfg, currentMetricsPolicyID)
+	if err != nil {
+		return 0, "", err
+	}
+	if statusCode == http.StatusNotFound {
+		return currentDays, defaultRetentionMaxSize, nil
+	}
+	days, err := getILMRetentionDays(policy)
+	if err != nil {
+		return 0, "", err
+	}
+	maxSize, err := getILMRetentionMaxSize(policy)
+	if err != nil {
+		maxSize = defaultRetentionMaxSize
+	}
+	return days, maxSize, nil
+}
+
+func updateRetentionSettings(client elastic.API, cfg *elastic.ElasticsearchConfig, days int, maxSize string) error {
+	requester, ok := client.(rawRequester)
+	if !ok {
+		return fmt.Errorf("cluster client does not support raw requests")
+	}
+	normalizedMaxSize, err := normalizeRetentionSize(maxSize)
+	if err != nil {
+		return err
+	}
+	indexPrefix := resolveSystemIndexPrefix()
+	if strings.EqualFold(cfg.Distribution, elastic.Opensearch) {
+		policyID := getMetricsRetentionPolicyID(indexPrefix, defaultRetentionDays)
+		response, statusCode, err := rawJSONRequest(
+			requester,
+			cfg,
+			util.Verb_GET,
+			"/_plugins/_ism/policies/"+url.PathEscape(policyID),
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+		if statusCode == http.StatusNotFound {
+			return fmt.Errorf("ism policy %s not found", policyID)
+		}
+		policy, ok := castMap(response["policy"])
+		if !ok {
+			return fmt.Errorf("ism policy payload not found")
+		}
+		if err := setISMRetentionDays(policy, days); err != nil {
+			return err
+		}
+		if err := setISMRetentionMaxSize(policy, normalizedMaxSize); err != nil {
+			return err
+		}
+		_, _, err = rawJSONRequest(
+			requester,
+			cfg,
+			util.Verb_PUT,
+			"/_plugins/_ism/policies/"+url.PathEscape(policyID),
+			util.MapStr{"policy": policy},
+		)
+		return err
+	}
+
+	currentMetricsPolicyID := getMetricsRetentionPolicyID(indexPrefix, defaultRetentionDays)
+	if template, statusCode, err := getLegacyTemplate(requester, cfg, indexPrefix+"metrics-rollover"); err != nil {
+		return err
+	} else if statusCode != http.StatusNotFound {
+		if policyID, err := readTemplateLifecyclePolicyID(template); err == nil {
+			currentMetricsPolicyID = policyID
+		}
+	}
+	newMetricsPolicyID := getMetricsRetentionPolicyID(indexPrefix, days)
+	metricsPolicy, seqNo, primaryTerm, statusCode, err := getILMPolicy(requester, cfg, currentMetricsPolicyID)
+	if err != nil {
+		return err
+	}
+	if statusCode == http.StatusNotFound {
+		return fmt.Errorf("ilm policy %s not found", currentMetricsPolicyID)
+	}
+	if err := setILMRetentionDays(metricsPolicy, days); err != nil {
+		return err
+	}
+	if err := setILMRetentionMaxSize(metricsPolicy, normalizedMaxSize); err != nil {
+		return err
+	}
+	if currentMetricsPolicyID != newMetricsPolicyID {
+		if err := deleteILMPolicy(requester, cfg, newMetricsPolicyID); err != nil {
+			return err
+		}
+		seqNo, primaryTerm = -1, -1
+	}
+	if err := putILMPolicy(requester, cfg, newMetricsPolicyID, metricsPolicy, seqNo, primaryTerm); err != nil {
+		return err
+	}
+
+	for _, templateName := range getManagedRetentionTemplateNames(indexPrefix) {
+		template, statusCode, err := getLegacyTemplate(requester, cfg, templateName)
+		if err != nil {
+			return err
+		}
+		if statusCode == http.StatusNotFound {
+			continue
+		}
+		if err := setTemplateLifecyclePolicyID(template, newMetricsPolicyID); err != nil {
+			return err
+		}
+		if err := putLegacyTemplate(requester, cfg, templateName, template); err != nil {
+			return err
+		}
+	}
+
+	_, _, err = rawJSONRequest(
+		requester,
+		cfg,
+		util.Verb_PUT,
+		"/"+strings.Join(getManagedRetentionIndexPatterns(indexPrefix), ",")+"/_settings?allow_no_indices=true&ignore_unavailable=true",
+		util.MapStr{
+			"index": util.MapStr{
+				"lifecycle": util.MapStr{
+					"name": newMetricsPolicyID,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	rollupTemplate, statusCode, err := getLegacyTemplate(requester, cfg, "rollup_policy_template")
+	if err != nil {
+		return err
+	}
+	if statusCode == http.StatusNotFound {
+		return nil
+	}
+	currentRollupPolicyID, err := readTemplateLifecyclePolicyID(rollupTemplate)
+	if err != nil {
+		return err
+	}
+	newRollupPolicyID := getRollupRetentionPolicyID(indexPrefix, days)
+	rollupPolicy, rollupSeqNo, rollupPrimaryTerm, statusCode, err := getILMPolicy(requester, cfg, currentRollupPolicyID)
+	if err != nil {
+		return err
+	}
+	if statusCode == http.StatusNotFound {
+		return fmt.Errorf("ilm policy %s not found", currentRollupPolicyID)
+	}
+	if err := setRollupILMRetentionDays(rollupPolicy, days); err != nil {
+		return err
+	}
+	if currentRollupPolicyID != newRollupPolicyID {
+		if err := deleteILMPolicy(requester, cfg, newRollupPolicyID); err != nil {
+			return err
+		}
+		rollupSeqNo, rollupPrimaryTerm = -1, -1
+	}
+	if err := putILMPolicy(requester, cfg, newRollupPolicyID, rollupPolicy, rollupSeqNo, rollupPrimaryTerm); err != nil {
+		return err
+	}
+	if err := setTemplateLifecyclePolicyID(rollupTemplate, newRollupPolicyID); err != nil {
+		return err
+	}
+	if err := putLegacyTemplate(requester, cfg, "rollup_policy_template", rollupTemplate); err != nil {
+		return err
+	}
+	_, _, err = rawJSONRequest(
+		requester,
+		cfg,
+		util.Verb_PUT,
+		"/rollup*/_settings?allow_no_indices=true&ignore_unavailable=true",
+		util.MapStr{
+			"index.lifecycle.name": newRollupPolicyID,
+		},
+	)
+	return err
+}
+
+func getRollupEnabled(client elastic.API) (bool, error) {
+	settings, err := client.GetClusterSettings(nil)
+	if err != nil {
+		return false, err
+	}
+	rollupEnabled, _ := util.GetMapValueByKeys([]string{"persistent", "rollup", "search", "enabled"}, settings)
+	switch value := rollupEnabled.(type) {
+	case string:
+		return strings.EqualFold(value, "true"), nil
+	case bool:
+		return value, nil
+	default:
+		return false, nil
+	}
+}
+
+func getSystemClusterClient() (elastic.API, *elastic.ElasticsearchConfig, error) {
+	systemClusterID := global.MustLookupString(elastic.GlobalSystemElasticsearchID)
+	cfg := elastic.GetConfigNoPanic(systemClusterID)
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("system cluster config not found")
+	}
+	client := elastic.GetClient(systemClusterID)
+	if client == nil {
+		return nil, nil, fmt.Errorf("system cluster client not found")
+	}
+	return client, cfg, nil
+}
+
+func (h *SettingsAPI) getRetentionSetting(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	client, cfg, err := getSystemClusterClient()
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	days, maxSize, err := getRetentionSettings(client, cfg)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	h.WriteJSON(w, util.MapStr{
+		"days":     days,
+		"max_size": maxSize,
+	}, http.StatusOK)
+}
+
+func (h *SettingsAPI) updateRetentionSetting(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	payload := retentionSettingsRequest{}
+	body, err := h.GetRawBody(req)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := util.FromJSONBytes(body, &payload); err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if payload.Days <= 0 {
+		h.WriteError(w, "retention days must be greater than 0", http.StatusBadRequest)
+		return
+	}
+
+	client, cfg, err := getSystemClusterClient()
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	currentMaxSize := defaultRetentionMaxSize
+	if payload.MaxSize == "" {
+		_, currentSize, err := getRetentionSettings(client, cfg)
+		if err != nil {
+			log.Error(err)
+			h.WriteError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		currentMaxSize = currentSize
+	} else {
+		currentMaxSize = payload.MaxSize
+	}
+	normalizedMaxSize, err := normalizeRetentionSize(currentMaxSize)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := updateRetentionSettings(client, cfg, payload.Days, normalizedMaxSize); err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	h.WriteJSON(w, util.MapStr{
+		"days":     payload.Days,
+		"max_size": normalizedMaxSize,
+	}, http.StatusOK)
+}
+
+func updateRollupJobs(client elastic.API, cfg *elastic.ElasticsearchConfig, action string) error {
+	requester, ok := client.(rawRequester)
+	if !ok {
+		return fmt.Errorf("cluster client does not support raw requests")
+	}
+	url := fmt.Sprintf("%s/_rollup/jobs/rollup*/_%s", cfg.GetAnyEndpoint(), action)
+	resp, err := requester.Request(context.Background(), util.Verb_POST, url, nil)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s", resp.Body)
+	}
+	return nil
+}
+
+func (h *SettingsAPI) getRollupSetting(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	client, _, err := getSystemClusterClient()
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	enabled, err := getRollupEnabled(client)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	h.WriteJSON(w, util.MapStr{
+		"enabled": enabled,
+	}, http.StatusOK)
+}
+
+func (h *SettingsAPI) updateRollupSetting(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	payload := rollupSettingsRequest{}
+	body, err := h.GetRawBody(req)
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := util.FromJSONBytes(body, &payload); err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	client, cfg, err := getSystemClusterClient()
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if !payload.Enabled {
+		err = updateRollupJobs(client, cfg, "stop")
+		if err != nil {
+			log.Error(err)
+			h.WriteError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	err = client.UpdateClusterSettings(util.MustToJSONBytes(util.MapStr{
+		"persistent": util.MapStr{
+			"rollup": util.MapStr{
+				"search": util.MapStr{
+					"enabled": fmt.Sprintf("%t", payload.Enabled),
+				},
+			},
+		},
+	}))
+	if err != nil {
+		log.Error(err)
+		h.WriteError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if payload.Enabled {
+		err = updateRollupJobs(client, cfg, "start")
+		if err != nil {
+			log.Error(err)
+			h.WriteError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	h.WriteJSON(w, util.MapStr{
+		"enabled": payload.Enabled,
+	}, http.StatusOK)
+}

--- a/plugin/api/settings/api_test.go
+++ b/plugin/api/settings/api_test.go
@@ -1,0 +1,493 @@
+package settings
+
+import "testing"
+
+func mustMap(t *testing.T, value interface{}) map[string]interface{} {
+	t.Helper()
+	mapped, ok := castMap(value)
+	if !ok {
+		t.Fatalf("expected map payload, got %T", value)
+	}
+	return mapped
+}
+
+func TestSetILMRetentionDays(t *testing.T) {
+	policy := map[string]interface{}{
+		"phases": map[string]interface{}{
+			"hot": map[string]interface{}{
+				"actions": map[string]interface{}{
+					"rollover": map[string]interface{}{
+						"max_age":  "30d",
+						"max_size": "50gb",
+					},
+				},
+			},
+			"delete": map[string]interface{}{
+				"min_age": "30d",
+			},
+		},
+	}
+
+	if err := setILMRetentionDays(policy, 90); err != nil {
+		t.Fatalf("setILMRetentionDays returned error: %v", err)
+	}
+
+	days, err := getILMRetentionDays(policy)
+	if err != nil {
+		t.Fatalf("getILMRetentionDays returned error: %v", err)
+	}
+	if days != 90 {
+		t.Fatalf("expected 90 retention days, got %d", days)
+	}
+}
+
+func TestNormalizeRetentionSize(t *testing.T) {
+	size, err := normalizeRetentionSize("50 GB")
+	if err != nil {
+		t.Fatalf("normalizeRetentionSize returned error: %v", err)
+	}
+	if size != "50gb" {
+		t.Fatalf("expected normalized size 50gb, got %s", size)
+	}
+}
+
+func TestSetILMRetentionDaysFromStates(t *testing.T) {
+	policy := map[string]interface{}{
+		"states": []interface{}{
+			map[string]interface{}{
+				"name": "hot",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"rollover": map[string]interface{}{
+							"min_index_age": "30d",
+						},
+					},
+				},
+				"transitions": []interface{}{
+					map[string]interface{}{
+						"state_name": "delete",
+						"conditions": map[string]interface{}{
+							"min_index_age": "30d",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := setILMRetentionDays(policy, 7); err != nil {
+		t.Fatalf("setILMRetentionDays returned error for states payload: %v", err)
+	}
+
+	days, err := getILMRetentionDays(policy)
+	if err != nil {
+		t.Fatalf("getILMRetentionDays returned error for states payload: %v", err)
+	}
+	if days != 7 {
+		t.Fatalf("expected 7 retention days, got %d", days)
+	}
+}
+
+func TestSetILMRetentionMaxSize(t *testing.T) {
+	policy := map[string]interface{}{
+		"phases": map[string]interface{}{
+			"hot": map[string]interface{}{
+				"actions": map[string]interface{}{
+					"rollover": map[string]interface{}{
+						"max_age":  "30d",
+						"max_size": "50gb",
+					},
+				},
+			},
+			"delete": map[string]interface{}{
+				"min_age": "30d",
+			},
+		},
+	}
+
+	if err := setILMRetentionMaxSize(policy, "80 GB"); err != nil {
+		t.Fatalf("setILMRetentionMaxSize returned error: %v", err)
+	}
+
+	size, err := getILMRetentionMaxSize(policy)
+	if err != nil {
+		t.Fatalf("getILMRetentionMaxSize returned error: %v", err)
+	}
+	if size != "80gb" {
+		t.Fatalf("expected 80gb retention size, got %s", size)
+	}
+}
+
+func TestNormalizeILMPolicyForPutFromStates(t *testing.T) {
+	policy := map[string]interface{}{
+		"states": []interface{}{
+			map[string]interface{}{
+				"name": "hot",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"retry": map[string]interface{}{
+							"count":   3,
+							"backoff": "exponential",
+							"delay":   "1m",
+						},
+						"rollover": map[string]interface{}{
+							"min_index_age": "30d",
+							"min_size":      "50gb",
+							"min_doc_count": 100000000,
+						},
+					},
+					map[string]interface{}{
+						"retry": map[string]interface{}{
+							"count":   3,
+							"backoff": "exponential",
+							"delay":   "1m",
+						},
+						"index_priority": map[string]interface{}{
+							"priority": 100,
+						},
+					},
+				},
+				"transitions": []interface{}{
+					map[string]interface{}{
+						"state_name": "delete",
+						"conditions": map[string]interface{}{
+							"min_index_age": "30d",
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"name": "delete",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"delete": nil,
+					},
+				},
+			},
+		},
+	}
+
+	if err := setILMRetentionDays(policy, 7); err != nil {
+		t.Fatalf("setILMRetentionDays returned error for states payload: %v", err)
+	}
+
+	normalized, err := normalizeILMPolicyForPut(policy)
+	if err != nil {
+		t.Fatalf("normalizeILMPolicyForPut returned error: %v", err)
+	}
+
+	phases := mustMap(t, normalized["phases"])
+	hotPhase := mustMap(t, phases["hot"])
+	if got := hotPhase["min_age"]; got != "0ms" {
+		t.Fatalf("expected hot min_age 0ms, got %v", got)
+	}
+	hotActions := mustMap(t, hotPhase["actions"])
+	rollover := mustMap(t, hotActions["rollover"])
+	if got := rollover["max_age"]; got != "7d" {
+		t.Fatalf("expected rollover max_age 7d, got %v", got)
+	}
+	if got := rollover["max_size"]; got != "50gb" {
+		t.Fatalf("expected rollover max_size 50gb, got %v", got)
+	}
+	if got := rollover["max_docs"]; got != 100000000 {
+		t.Fatalf("expected rollover max_docs 100000000, got %v", got)
+	}
+	if _, exists := rollover["min_index_age"]; exists {
+		t.Fatalf("expected rollover min_index_age to be removed, got %#v", rollover)
+	}
+	if _, exists := rollover["min_size"]; exists {
+		t.Fatalf("expected rollover min_size to be removed, got %#v", rollover)
+	}
+	if _, exists := rollover["min_doc_count"]; exists {
+		t.Fatalf("expected rollover min_doc_count to be removed, got %#v", rollover)
+	}
+	if _, exists := hotActions["retry"]; exists {
+		t.Fatalf("expected retry metadata to be stripped from ILM actions, got %#v", hotActions)
+	}
+
+	setPriority := mustMap(t, hotActions["set_priority"])
+	if got := setPriority["priority"]; got != 100 {
+		t.Fatalf("expected set_priority priority 100, got %v", got)
+	}
+
+	deletePhase := mustMap(t, phases["delete"])
+	if got := deletePhase["min_age"]; got != "7d" {
+		t.Fatalf("expected delete min_age 7d, got %v", got)
+	}
+	deleteActions := mustMap(t, deletePhase["actions"])
+	if got := deleteActions["delete"]; got == nil {
+		t.Fatalf("expected delete action payload to be an object, got nil")
+	}
+	deletePayload := mustMap(t, deleteActions["delete"])
+	if len(deletePayload) != 0 {
+		t.Fatalf("expected empty delete action payload, got %#v", deleteActions["delete"])
+	}
+}
+
+func TestSetISMRetentionDays(t *testing.T) {
+	policy := map[string]interface{}{
+		"states": []interface{}{
+			map[string]interface{}{
+				"name": "hot",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"rollover": map[string]interface{}{
+							"min_index_age": "30d",
+							"min_size":      "50gb",
+						},
+					},
+				},
+				"transitions": []interface{}{
+					map[string]interface{}{
+						"state_name": "delete",
+						"conditions": map[string]interface{}{
+							"min_index_age": "30d",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := setISMRetentionDays(policy, 60); err != nil {
+		t.Fatalf("setISMRetentionDays returned error: %v", err)
+	}
+
+	days, err := getISMRetentionDays(policy)
+	if err != nil {
+		t.Fatalf("getISMRetentionDays returned error: %v", err)
+	}
+	if days != 60 {
+		t.Fatalf("expected 60 retention days, got %d", days)
+	}
+}
+
+func TestSetISMRetentionMaxSize(t *testing.T) {
+	policy := map[string]interface{}{
+		"states": []interface{}{
+			map[string]interface{}{
+				"name": "hot",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"rollover": map[string]interface{}{
+							"min_index_age": "30d",
+							"min_size":      "50gb",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := setISMRetentionMaxSize(policy, "120g"); err != nil {
+		t.Fatalf("setISMRetentionMaxSize returned error: %v", err)
+	}
+
+	size, err := getISMRetentionMaxSize(policy)
+	if err != nil {
+		t.Fatalf("getISMRetentionMaxSize returned error: %v", err)
+	}
+	if size != "120gb" {
+		t.Fatalf("expected 120gb retention size, got %s", size)
+	}
+}
+
+func TestSetRollupILMRetentionDaysFromStates(t *testing.T) {
+	policy := map[string]interface{}{
+		"states": []interface{}{
+			map[string]interface{}{
+				"name": "hot",
+				"transitions": []interface{}{
+					map[string]interface{}{
+						"state_name": "delete",
+						"conditions": map[string]interface{}{
+							"min_index_age": "30d",
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"name": "delete",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"delete": map[string]interface{}{
+							"min_data_age": "30d",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := setRollupILMRetentionDays(policy, 7); err != nil {
+		t.Fatalf("setRollupILMRetentionDays returned error for states payload: %v", err)
+	}
+
+	states := policy["states"].([]interface{})
+	hotState := mustMap(t, states[0])
+	transition := mustMap(t, hotState["transitions"].([]interface{})[0])
+	if got := mustMap(t, transition["conditions"])["min_index_age"]; got != "7d" {
+		t.Fatalf("expected transition min_index_age 7d, got %v", got)
+	}
+
+	deleteState := mustMap(t, states[1])
+	deleteAction := mustMap(t, mustMap(t, deleteState["actions"].([]interface{})[0])["delete"])
+	if got := deleteAction["min_data_age"]; got != "7d" {
+		t.Fatalf("expected delete min_data_age 7d, got %v", got)
+	}
+}
+
+func TestNormalizeRollupILMPolicyForPutFromStates(t *testing.T) {
+	policy := map[string]interface{}{
+		"states": []interface{}{
+			map[string]interface{}{
+				"name": "hot",
+				"transitions": []interface{}{
+					map[string]interface{}{
+						"state_name": "delete",
+						"conditions": map[string]interface{}{
+							"min_index_age": "30d",
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"name": "delete",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"delete": map[string]interface{}{
+							"timestamp_field": "timestamp.date_histogram",
+							"min_data_age":    "30d",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := setRollupILMRetentionDays(policy, 7); err != nil {
+		t.Fatalf("setRollupILMRetentionDays returned error for states payload: %v", err)
+	}
+
+	normalized, err := normalizeILMPolicyForPut(policy)
+	if err != nil {
+		t.Fatalf("normalizeILMPolicyForPut returned error: %v", err)
+	}
+
+	phases := mustMap(t, normalized["phases"])
+	deletePhase := mustMap(t, phases["delete"])
+	if got := deletePhase["min_age"]; got != "7d" {
+		t.Fatalf("expected delete min_age 7d, got %v", got)
+	}
+
+	deleteAction := mustMap(t, mustMap(t, deletePhase["actions"])["delete"])
+	if got := deleteAction["min_data_age"]; got != "7d" {
+		t.Fatalf("expected delete min_data_age 7d, got %v", got)
+	}
+	if got := deleteAction["timestamp_field"]; got != "timestamp.date_histogram" {
+		t.Fatalf("expected timestamp_field to be preserved, got %v", got)
+	}
+}
+
+func TestParseRetentionDays(t *testing.T) {
+	days, err := parseRetentionDays("30d")
+	if err != nil {
+		t.Fatalf("parseRetentionDays returned error: %v", err)
+	}
+	if days != 30 {
+		t.Fatalf("expected 30 retention days, got %d", days)
+	}
+}
+
+func TestParseRetentionDaysFromPolicyID(t *testing.T) {
+	days, err := parseRetentionDaysFromPolicyID("ilm_.infini_metrics-7days-retention")
+	if err != nil {
+		t.Fatalf("parseRetentionDaysFromPolicyID returned error: %v", err)
+	}
+	if days != 7 {
+		t.Fatalf("expected 7 retention days, got %d", days)
+	}
+}
+
+func TestSetRollupILMRetentionDays(t *testing.T) {
+	policy := map[string]interface{}{
+		"phases": map[string]interface{}{
+			"hot": map[string]interface{}{
+				"min_age": "0ms",
+			},
+			"delete": map[string]interface{}{
+				"min_age": "30d",
+				"actions": map[string]interface{}{
+					"delete": map[string]interface{}{
+						"min_data_age": "30d",
+					},
+				},
+			},
+		},
+	}
+
+	if err := setRollupILMRetentionDays(policy, 7); err != nil {
+		t.Fatalf("setRollupILMRetentionDays returned error: %v", err)
+	}
+
+	deletePhase := mustMap(t, mustMap(t, policy["phases"])["delete"])
+	if got := deletePhase["min_age"]; got != "7d" {
+		t.Fatalf("expected delete min_age 7d, got %v", got)
+	}
+	deleteAction := mustMap(t, mustMap(t, deletePhase["actions"])["delete"])
+	if got := deleteAction["min_data_age"]; got != "7d" {
+		t.Fatalf("expected delete min_data_age 7d, got %v", got)
+	}
+}
+
+func TestExtractILMPolicyByExactPolicyID(t *testing.T) {
+	response := map[string]interface{}{
+		"ilm_.infini_metrics-30days-retention": map[string]interface{}{
+			"policy": map[string]interface{}{
+				"phases": map[string]interface{}{},
+			},
+		},
+	}
+
+	policy, err := extractILMPolicy(response, "ilm_.infini_metrics-30days-retention")
+	if err != nil {
+		t.Fatalf("extractILMPolicy returned error: %v", err)
+	}
+	if _, ok := policy["phases"]; !ok {
+		t.Fatalf("expected extracted policy phases, got %#v", policy)
+	}
+}
+
+func TestExtractILMPolicyFromSingleEntryFallback(t *testing.T) {
+	response := map[string]interface{}{
+		"ilm_.infini_metrics-7days-retention": map[string]interface{}{
+			"policy": map[string]interface{}{
+				"phases": map[string]interface{}{},
+			},
+		},
+	}
+
+	policy, err := extractILMPolicy(response, "ilm_.infini_metrics-30days-retention")
+	if err != nil {
+		t.Fatalf("extractILMPolicy returned error: %v", err)
+	}
+	if _, ok := policy["phases"]; !ok {
+		t.Fatalf("expected extracted policy phases, got %#v", policy)
+	}
+}
+
+func TestExtractILMPolicyFromDirectBody(t *testing.T) {
+	response := map[string]interface{}{
+		"policy": map[string]interface{}{
+			"phases": map[string]interface{}{},
+		},
+	}
+
+	policy, err := extractILMPolicy(response, "ilm_.infini_metrics-30days-retention")
+	if err != nil {
+		t.Fatalf("extractILMPolicy returned error: %v", err)
+	}
+	if _, ok := policy["phases"]; !ok {
+		t.Fatalf("expected extracted policy phases, got %#v", policy)
+	}
+}

--- a/web/config/router.config.js
+++ b/web/config/router.config.js
@@ -381,6 +381,8 @@ export default [
         name: "system",
         icon: "setting",
         authority: [
+          "system.cluster:all",
+          "system.cluster:read",
           "system.credential:all",
           "system.credential:read",
           "system.security:all",
@@ -392,10 +394,26 @@ export default [
         ],
         routes: [
           {
+            path: "/system/settings",
+            name: "settings",
+            component: "./System/Settings/index",
+            authority: [
+              "system.cluster:all",
+              "system.cluster:read",
+              "system.smtp_server:all",
+              "system.smtp_server:read",
+            ],
+          },
+          {
             path: "/system/email_server",
-            name: "smtp_server",
-            component: "./System/Email/Server",
-            authority: ["system.smtp_server:all", "system.smtp_server:read"],
+            component: "./System/Settings/index",
+            hideInMenu: true,
+            authority: [
+              "system.cluster:all",
+              "system.cluster:read",
+              "system.smtp_server:all",
+              "system.smtp_server:read",
+            ],
           },
           {
             path: "/system/credential",

--- a/web/src/locales/en-US/settings.js
+++ b/web/src/locales/en-US/settings.js
@@ -3,4 +3,29 @@ export default {
   "settings.email.server.empty.label2":
     "The alart center can send a notification to the recipient through the designated mail server",
   "settings.email.server.empty.button.new": "Add email server",
+  "settings.system.tab.general": "General",
+  "settings.system.tab.email": "Email Server",
+  "settings.system.retention.title": "Data Retention",
+  "settings.system.retention.description":
+    "Update how many days system-managed data is retained before ILM deletes it.",
+  "settings.system.retention.help":
+    "The default retention is 30 days and the default rollover size is 50 GB. Saving this setting updates the system ILM retention policy for managed system indices.",
+  "settings.system.retention.unit": "days",
+  "settings.system.retention.size.label": "Rollover size",
+  "settings.system.retention.size.unit": "GB",
+  "settings.system.retention.save": "Save",
+  "settings.system.retention.update.success":
+    "Data retention updated successfully",
+  "settings.system.retention.validation.days":
+    "Please enter a valid retention days value",
+  "settings.system.retention.validation.max_size":
+    "Please enter a valid rollover size in GB, such as 50",
+  "settings.system.rollup.title": "Rollup",
+  "settings.system.rollup.description":
+    "Enable or stop the system cluster rollup jobs from Console system settings.",
+  "settings.system.rollup.enabled": "On",
+  "settings.system.rollup.disabled": "Off",
+  "settings.system.rollup.help":
+    "Turning Rollup off will stop rollup jobs and disable rollup search in cluster settings.",
+  "settings.system.rollup.update.success": "Rollup setting updated successfully",
 };

--- a/web/src/locales/zh-CN/settings.js
+++ b/web/src/locales/zh-CN/settings.js
@@ -3,4 +3,27 @@ export default {
   "settings.email.server.empty.label2":
     "告警中心可通指定的邮件服务器向收件人发送通知",
   "settings.email.server.empty.button.new": "添加邮件服务器",
+  "settings.system.tab.general": "通用设置",
+  "settings.system.tab.email": "邮件服务器",
+  "settings.system.retention.title": "数据保留天数",
+  "settings.system.retention.description":
+    "设置系统托管数据在被 ILM 删除前保留多少天。",
+  "settings.system.retention.help":
+    "默认保留 30 天，默认滚动存储大小为 50 GB。保存后会更新系统托管索引对应的 ILM 保留策略。",
+  "settings.system.retention.unit": "天",
+  "settings.system.retention.size.label": "滚动存储大小",
+  "settings.system.retention.size.unit": "GB",
+  "settings.system.retention.save": "保存",
+  "settings.system.retention.update.success": "数据保留天数已更新",
+  "settings.system.retention.validation.days": "请输入有效的保留天数",
+  "settings.system.retention.validation.max_size":
+    "请输入有效的滚动存储大小，单位为 GB，例如 50",
+  "settings.system.rollup.title": "Rollup",
+  "settings.system.rollup.description":
+    "可在系统设置中启用或停止系统集群的 Rollup 任务。",
+  "settings.system.rollup.enabled": "开启",
+  "settings.system.rollup.disabled": "关闭",
+  "settings.system.rollup.help":
+    "关闭 Rollup 会停止 rollup job，并同步关闭集群设置中的 rollup search。",
+  "settings.system.rollup.update.success": "Rollup 设置已更新",
 };

--- a/web/src/pages/System/Email/Server.jsx
+++ b/web/src/pages/System/Email/Server.jsx
@@ -9,7 +9,7 @@ import { formatESSearchResult } from '@/lib/elasticsearch/util';
 import { formatMessage } from "umi/locale";
 import EmptyServer from './Components/EmptyServer';
 
-const ServerList = ({})=>{
+const ServerList = ({ embedded = false })=>{
 
   const [loading, setLoading] = useState(false);
   
@@ -151,38 +151,42 @@ const ServerList = ({})=>{
       }
     })
   }
+  const content = (
+    <Card loading={loading}>
+      {state.servers.length == 0 ? <EmptyServer onAddClick={onEmptyAddClick}/>:
+      <Tabs
+        hideAdd
+        onChange={handleTabChange}
+        activeKey={state.activeKey}
+        type="editable-card"
+        // onEdit={this.onEdit}
+      >
+        {state.servers.map(cfg => (
+          <TabPane 
+          tab={<span className='srv-tab'>{cfg.name}
+           <Popconfirm
+                title="Sure to delete?"
+                onConfirm={() => onDeleteClick(cfg.id)}
+              >
+                <Icon type="close"/>
+            </Popconfirm>
+          </span>} 
+          key={cfg.id} closable={false} >
+            <ServerConfig config={cfg} setState={setState} onSaveClick={onSaveClick}/>
+            <div></div>
+          </TabPane>
+        ))}
+         <TabPane tab={<span>
+        <Icon type="plus" />
+      </span>} key="add" closable={false} />
+      </Tabs>}
+    </Card>
+  );
+  if (embedded) {
+    return content;
+  }
   return (
-    <PageHeaderWrapper>
-      <Card loading={loading}>
-        {state.servers.length == 0 ? <EmptyServer onAddClick={onEmptyAddClick}/>:
-        <Tabs
-          hideAdd
-          onChange={handleTabChange}
-          activeKey={state.activeKey}
-          type="editable-card"
-          // onEdit={this.onEdit}
-        >
-          {state.servers.map(cfg => (
-            <TabPane 
-            tab={<span className='srv-tab'>{cfg.name}
-             <Popconfirm
-                  title="Sure to delete?"
-                  onConfirm={() => onDeleteClick(cfg.id)}
-                >
-                  <Icon type="close"/>
-              </Popconfirm>
-            </span>} 
-            key={cfg.id} closable={false} >
-              <ServerConfig config={cfg} setState={setState} onSaveClick={onSaveClick}/>
-              <div></div>
-            </TabPane>
-          ))}
-           <TabPane tab={<span>
-          <Icon type="plus" />
-        </span>} key="add" closable={false} />
-        </Tabs>}
-      </Card>
-    </PageHeaderWrapper>
+    <PageHeaderWrapper>{content}</PageHeaderWrapper>
   );
 }
 

--- a/web/src/pages/System/Settings/index.jsx
+++ b/web/src/pages/System/Settings/index.jsx
@@ -1,0 +1,352 @@
+import PageHeaderWrapper from "@/components/PageHeaderWrapper";
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  InputNumber,
+  Spin,
+  Switch,
+  Tabs,
+  message,
+} from "antd";
+import { formatMessage } from "umi/locale";
+import router from "umi/router";
+import { useEffect, useMemo, useState } from "react";
+import request from "@/utils/request";
+import ServerList from "../Email/Server";
+import { hasAuthority } from "@/utils/authority";
+
+const { TabPane } = Tabs;
+
+const SystemSettings = (props) => {
+  const query = new URLSearchParams(props.location?.search || "");
+  const pathDefaultTab = props.location?.pathname?.includes("/email_server")
+    ? "email"
+    : "general";
+  const canReadCluster =
+    hasAuthority("system.cluster:all") || hasAuthority("system.cluster:read");
+  const canWriteCluster = hasAuthority("system.cluster:all");
+  const canReadEmail =
+    hasAuthority("system.smtp_server:all") ||
+    hasAuthority("system.smtp_server:read");
+  const tabs = useMemo(() => {
+    const nextTabs = [];
+    if (canReadCluster) {
+      nextTabs.push("general");
+    }
+    if (canReadEmail) {
+      nextTabs.push("email");
+    }
+    return nextTabs;
+  }, [canReadCluster, canReadEmail]);
+  const [activeTab, setActiveTab] = useState(
+    query.get("tab") || pathDefaultTab || tabs[0] || "general"
+  );
+  const defaultRetentionMaxSize = 50;
+  const [retentionDays, setRetentionDays] = useState(30);
+  const [retentionDraftDays, setRetentionDraftDays] = useState(30);
+  const [retentionMaxSize, setRetentionMaxSize] = useState(defaultRetentionMaxSize);
+  const [retentionDraftMaxSize, setRetentionDraftMaxSize] = useState(
+    defaultRetentionMaxSize
+  );
+  const [retentionLoading, setRetentionLoading] = useState(false);
+  const [rollupEnabled, setRollupEnabled] = useState(false);
+  const [rollupLoading, setRollupLoading] = useState(false);
+
+  const normalizeRetentionSize = (value) =>
+    `${value || ""}`.replace(/\s+/g, "").toLowerCase();
+
+  const parseRetentionSizeToGb = (value) => {
+    const normalizedValue = normalizeRetentionSize(value);
+    const matches = normalizedValue.match(/^(\d+)(b|kb|mb|gb|tb|k|m|g|t)$/i);
+    if (!matches) {
+      return defaultRetentionMaxSize;
+    }
+    const size = Number(matches[1]);
+    const unit = matches[2].toLowerCase();
+    const multiplier = {
+      b: 1 / 1024 / 1024 / 1024,
+      kb: 1 / 1024 / 1024,
+      k: 1 / 1024 / 1024,
+      mb: 1 / 1024,
+      m: 1 / 1024,
+      gb: 1,
+      g: 1,
+      tb: 1024,
+      t: 1024,
+    }[unit];
+    if (!multiplier) {
+      return defaultRetentionMaxSize;
+    }
+    return Math.max(1, Math.ceil(size * multiplier));
+  };
+
+  const isValidRetentionSize = (value) =>
+    Number.isInteger(value) && value > 0;
+
+  useEffect(() => {
+    if (tabs.length > 0 && !tabs.includes(activeTab)) {
+      setActiveTab(tabs[0]);
+    }
+  }, [tabs, activeTab]);
+
+  useEffect(() => {
+    if (!canReadCluster) {
+      return;
+    }
+    const fetchRetentionSetting = async () => {
+      setRetentionLoading(true);
+      const res = await request("/setting/system/retention", {
+        method: "GET",
+      });
+      if (!res?.error && Number.isInteger(res.days) && res.days > 0) {
+        setRetentionDays(res.days);
+        setRetentionDraftDays(res.days);
+        if (res.max_size) {
+          const normalizedSize = parseRetentionSizeToGb(res.max_size);
+          setRetentionMaxSize(normalizedSize);
+          setRetentionDraftMaxSize(normalizedSize);
+        }
+      }
+      setRetentionLoading(false);
+    };
+    const fetchRollupSetting = async () => {
+      setRollupLoading(true);
+      const res = await request("/setting/system/rollup", {
+        method: "GET",
+      });
+      if (!res?.error) {
+        setRollupEnabled(!!res.enabled);
+      }
+      setRollupLoading(false);
+    };
+    fetchRetentionSetting();
+    fetchRollupSetting();
+  }, [canReadCluster]);
+
+  const onTabChange = (key) => {
+    setActiveTab(key);
+    router.replace(`/system/settings?tab=${key}`);
+  };
+
+  const onRollupToggle = async (checked) => {
+    const previousValue = rollupEnabled;
+    setRollupEnabled(checked);
+    setRollupLoading(true);
+    const res = await request("/setting/system/rollup", {
+      method: "PUT",
+      body: {
+        enabled: checked,
+      },
+    });
+    if (res?.error) {
+      setRollupEnabled(previousValue);
+      setRollupLoading(false);
+      return;
+    }
+    localStorage.setItem("infini-rollup-enabled", `${checked}`);
+    setRollupLoading(false);
+    message.success(
+      formatMessage({ id: "settings.system.rollup.update.success" })
+    );
+  };
+
+  const onRetentionSave = async () => {
+    if (!Number.isInteger(retentionDraftDays) || retentionDraftDays <= 0) {
+      message.warning(
+        formatMessage({ id: "settings.system.retention.validation.days" })
+      );
+      return;
+    }
+    if (!isValidRetentionSize(retentionDraftMaxSize)) {
+      message.warning(
+        formatMessage({ id: "settings.system.retention.validation.max_size" })
+      );
+      return;
+    }
+    setRetentionLoading(true);
+    const normalizedMaxSize = normalizeRetentionSize(`${retentionDraftMaxSize}gb`);
+    const res = await request("/setting/system/retention", {
+      method: "PUT",
+      body: {
+        days: retentionDraftDays,
+        max_size: normalizedMaxSize,
+      },
+    });
+    if (res?.error) {
+      setRetentionLoading(false);
+      return;
+    }
+    setRetentionDays(res.days);
+    setRetentionDraftDays(res.days);
+    setRetentionMaxSize(parseRetentionSizeToGb(res.max_size || normalizedMaxSize));
+    setRetentionDraftMaxSize(
+      parseRetentionSizeToGb(res.max_size || normalizedMaxSize)
+    );
+    setRetentionLoading(false);
+    message.success(
+      formatMessage({ id: "settings.system.retention.update.success" })
+    );
+  };
+
+  const renderRetentionSettings = () => {
+    if (!canReadCluster) {
+      return null;
+    }
+    return (
+      <Spin spinning={retentionLoading}>
+        <Card bordered={false} style={{ marginBottom: 16 }}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <div>
+              <div style={{ fontSize: 16, fontWeight: 500, marginBottom: 8 }}>
+                {formatMessage({ id: "settings.system.retention.title" })}
+              </div>
+              <div style={{ color: "rgba(0,0,0,0.65)", marginBottom: 16 }}>
+                {formatMessage({
+                  id: "settings.system.retention.description",
+                })}
+              </div>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginLeft: 16,
+              }}
+            >
+              <InputNumber
+                min={1}
+                precision={0}
+                value={retentionDraftDays}
+                disabled={!canWriteCluster || retentionLoading}
+                onChange={(value) => {
+                  setRetentionDraftDays(
+                    Number.isInteger(value) ? value : retentionDraftDays
+                  );
+                }}
+              />
+              <span>{formatMessage({ id: "settings.system.retention.unit" })}</span>
+              <span style={{ marginLeft: 8 }}>
+                {formatMessage({ id: "settings.system.retention.size.label" })}
+              </span>
+              <InputNumber
+                min={1}
+                precision={0}
+                style={{ width: 120 }}
+                value={retentionDraftMaxSize}
+                disabled={!canWriteCluster || retentionLoading}
+                placeholder="50"
+                onChange={(value) => {
+                  setRetentionDraftMaxSize(
+                    Number.isInteger(value) ? value : retentionDraftMaxSize
+                  );
+                }}
+              />
+              <span>{formatMessage({ id: "settings.system.retention.size.unit" })}</span>
+              <Button
+                type="primary"
+                loading={retentionLoading}
+                disabled={
+                  !canWriteCluster ||
+                  !Number.isInteger(retentionDraftDays) ||
+                  retentionDraftDays <= 0 ||
+                  !isValidRetentionSize(retentionDraftMaxSize) ||
+                  (retentionDraftDays === retentionDays &&
+                    retentionDraftMaxSize === retentionMaxSize)
+                }
+                onClick={onRetentionSave}
+              >
+                {formatMessage({ id: "settings.system.retention.save" })}
+              </Button>
+            </div>
+          </div>
+          <Alert
+            type="info"
+            showIcon
+            message={<div>{formatMessage({ id: "settings.system.retention.help" })}</div>}
+          />
+        </Card>
+      </Spin>
+    );
+  };
+
+  const renderRollupSettings = () => {
+    if (!canReadCluster) {
+      return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />;
+    }
+    return (
+      <Spin spinning={rollupLoading}>
+        <Card bordered={false}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <div>
+              <div style={{ fontSize: 16, fontWeight: 500, marginBottom: 8 }}>
+                {formatMessage({ id: "settings.system.rollup.title" })}
+              </div>
+              <div style={{ color: "rgba(0,0,0,0.65)", marginBottom: 16 }}>
+                {formatMessage({ id: "settings.system.rollup.description" })}
+              </div>
+            </div>
+            <Switch
+              checked={rollupEnabled}
+              loading={rollupLoading}
+              disabled={!canWriteCluster}
+              checkedChildren={formatMessage({
+                id: "settings.system.rollup.enabled",
+              })}
+              unCheckedChildren={formatMessage({
+                id: "settings.system.rollup.disabled",
+              })}
+              onChange={onRollupToggle}
+            />
+          </div>
+          <Alert
+            type="info"
+            showIcon
+            message={formatMessage({ id: "settings.system.rollup.help" })}
+          />
+        </Card>
+      </Spin>
+    );
+  };
+
+  const renderGeneralSettings = () => {
+    if (!canReadCluster) {
+      return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description=""/>;
+    }
+    return (
+      <>
+        {renderRetentionSettings()}
+        {renderRollupSettings()}
+      </>
+    );
+  };
+
+  return (
+    <PageHeaderWrapper>
+      <Card>
+        <Tabs activeKey={activeTab} onChange={onTabChange}>
+          {canReadCluster ? (
+            <TabPane
+              tab={formatMessage({ id: "settings.system.tab.general" })}
+              key="general"
+            >
+              {renderGeneralSettings()}
+            </TabPane>
+          ) : null}
+          {canReadEmail ? (
+            <TabPane
+              tab={formatMessage({ id: "settings.system.tab.email" })}
+              key="email"
+            >
+              <ServerList embedded />
+            </TabPane>
+          ) : null}
+        </Tabs>
+      </Card>
+    </PageHeaderWrapper>
+  );
+};
+
+export default SystemSettings;


### PR DESCRIPTION
## Summary
- add backend APIs and tests for system retention and rollup settings
- add a /system/settings page with general and email tabs
- route /system/email_server through the new settings page and embed the email server list

## Testing
- go test ./plugin/api/settings ./plugin/api
- NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' ./node_modules/.bin/umi build