### PR TITLE
improve: support cluster probe paths and clearer connection errors

### DIFF
--- a/common/probe.go
+++ b/common/probe.go
@@ -1,0 +1,199 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/segmentio/encoding/json"
+	"infini.sh/framework/core/elastic"
+	"infini.sh/framework/core/errors"
+	"infini.sh/framework/core/util"
+	"infini.sh/framework/modules/elastic/adapter"
+)
+
+const ClusterProbePathLabel = "console_probe_path"
+
+func NormalizeProbePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || path == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path
+}
+
+func GetProbePath(config *elastic.ElasticsearchConfig) string {
+	if config == nil || config.Labels == nil {
+		return ""
+	}
+	return NormalizeProbePath(util.ToString(config.Labels[ClusterProbePathLabel]))
+}
+
+func SetProbePath(config *elastic.ElasticsearchConfig, path string) {
+	if config == nil {
+		return
+	}
+	path = NormalizeProbePath(path)
+	if config.Labels == nil {
+		config.Labels = util.MapStr{}
+	}
+	if path == "" {
+		delete(config.Labels, ClusterProbePathLabel)
+		return
+	}
+	config.Labels[ClusterProbePathLabel] = path
+}
+
+func BuildEndpointWithPath(endpoint, path string) string {
+	path = NormalizeProbePath(path)
+	if path == "" {
+		return endpoint
+	}
+
+	baseURL, err := url.Parse(endpoint)
+	if err != nil {
+		return strings.TrimRight(endpoint, "/") + path
+	}
+
+	refURL, err := url.Parse(path)
+	if err != nil {
+		return strings.TrimRight(endpoint, "/") + path
+	}
+
+	return baseURL.ResolveReference(refURL).String()
+}
+
+func ClusterVersion(metadata *elastic.ElasticsearchMetadata) (*elastic.ClusterInformation, error) {
+	if metadata == nil || metadata.Config == nil {
+		return nil, errors.New("elasticsearch metadata is nil")
+	}
+
+	probePath := GetProbePath(metadata.Config)
+	if probePath == "" {
+		return adapter.ClusterVersion(metadata)
+	}
+
+	if metadata.Config.RequestTimeout <= 0 {
+		metadata.Config.RequestTimeout = 5
+	}
+
+	endpoint := fmt.Sprintf("%v://%v", metadata.GetSchema(), metadata.GetActiveHost())
+	if err := probeClusterEndpoint(metadata.Config, endpoint, probePath); err != nil {
+		return nil, err
+	}
+	return loadClusterInformationWithoutRoot(metadata.Config, endpoint)
+}
+
+func ClusterVersionWithConfig(config *elastic.ElasticsearchConfig) (*elastic.ClusterInformation, error) {
+	if config == nil {
+		return nil, errors.New("elasticsearch config is nil")
+	}
+	return ClusterVersion(&elastic.ElasticsearchMetadata{Config: config})
+}
+
+func probeClusterEndpoint(config *elastic.ElasticsearchConfig, endpoint, probePath string) error {
+	res, err := executeRequest(config, BuildEndpointWithPath(endpoint, probePath))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return errors.New(string(res.Body))
+	}
+	return nil
+}
+
+func loadClusterInformationWithoutRoot(config *elastic.ElasticsearchConfig, endpoint string) (*elastic.ClusterInformation, error) {
+	stats := &elastic.ClusterStats{}
+	res, err := executeRequest(config, BuildEndpointWithPath(endpoint, "/_cluster/stats"))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New(string(res.Body))
+	}
+	if err = json.Unmarshal(res.Body, stats); err != nil {
+		return nil, err
+	}
+
+	nodes := &elastic.NodesResponse{}
+	res, err = executeRequest(config, BuildEndpointWithPath(endpoint, "/_nodes/_all/http"))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New(string(res.Body))
+	}
+	if err = json.Unmarshal(res.Body, nodes); err != nil {
+		return nil, err
+	}
+
+	info := &elastic.ClusterInformation{
+		ClusterName: stats.ClusterName,
+		ClusterUUID: stats.ClusterUUID,
+	}
+	if info.ClusterName == "" {
+		info.ClusterName = nodes.ClusterName
+	}
+	for _, node := range nodes.Nodes {
+		if node.Version != "" {
+			info.Version.Number = node.Version
+			break
+		}
+	}
+	info.Version.Distribution = config.Distribution
+	if info.Version.Distribution == "" {
+		info.Version.Distribution = elastic.Elasticsearch
+	}
+	return info, nil
+}
+
+func executeRequest(config *elastic.ElasticsearchConfig, requestURL string) (*util.Result, error) {
+	req := util.Request{
+		Method: http.MethodGet,
+		Url:    requestURL,
+	}
+	if config.BasicAuth != nil && strings.TrimSpace(config.BasicAuth.Username) != "" {
+		req.SetBasicAuth(config.BasicAuth.Username, config.BasicAuth.Password.Get())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(getRequestTimeout(config))*time.Second)
+	req.Context = ctx
+	defer cancel()
+
+	return util.ExecuteRequestWithCatchFlag(nil, &req, true)
+}
+
+func getRequestTimeout(config *elastic.ElasticsearchConfig) int {
+	if config == nil || config.RequestTimeout <= 0 {
+		return 5
+	}
+	return config.RequestTimeout
+}

--- a/common/probe_test.go
+++ b/common/probe_test.go
@@ -1,0 +1,68 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/elastic"
+)
+
+func TestNormalizeProbePath(t *testing.T) {
+	tests := map[string]string{
+		"":                "",
+		"   ":             "",
+		"/":               "",
+		"_cluster/health": "/_cluster/health",
+		" /_cat/nodes ":   "/_cat/nodes",
+	}
+
+	for input, expected := range tests {
+		if got := NormalizeProbePath(input); got != expected {
+			t.Fatalf("NormalizeProbePath(%q) = %q, want %q", input, got, expected)
+		}
+	}
+}
+
+func TestProbePathStoredInLabels(t *testing.T) {
+	cfg := &elastic.ElasticsearchConfig{}
+	SetProbePath(cfg, "_cluster/health")
+
+	if got := GetProbePath(cfg); got != "/_cluster/health" {
+		t.Fatalf("GetProbePath() = %q, want %q", got, "/_cluster/health")
+	}
+
+	SetProbePath(cfg, "")
+	if got := GetProbePath(cfg); got != "" {
+		t.Fatalf("GetProbePath() = %q, want empty", got)
+	}
+}
+
+func TestBuildEndpointWithPath(t *testing.T) {
+	got := BuildEndpointWithPath("https://example.com:9200", "/_cluster/health")
+	want := "https://example.com:9200/_cluster/health"
+	if got != want {
+		t.Fatalf("BuildEndpointWithPath() = %q, want %q", got, want)
+	}
+}

--- a/modules/agent/api/elasticsearch.go
+++ b/modules/agent/api/elasticsearch.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/buger/jsonparser"
 	log "github.com/cihub/seelog"
+	console_common "infini.sh/console/common"
 	"infini.sh/console/plugin/managed/server"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/elastic"
@@ -45,7 +46,6 @@ import (
 	"infini.sh/framework/core/model"
 	"infini.sh/framework/core/orm"
 	"infini.sh/framework/core/util"
-	"infini.sh/framework/modules/elastic/adapter"
 	"infini.sh/framework/modules/elastic/common"
 	"infini.sh/framework/modules/elastic/metadata"
 )
@@ -170,7 +170,7 @@ func refreshNodesInfo(instanceID, instanceEndpoint string) (*elastic.DiscoveryRe
 					continue
 				}
 			} else {
-				clusterInfo, err = adapter.ClusterVersion(elastic.GetMetadata(v.ClusterID))
+				clusterInfo, err = console_common.ClusterVersion(elastic.GetMetadata(v.ClusterID))
 				if err != nil || clusterInfo == nil {
 					log.Error(err)
 					continue

--- a/modules/elastic/api/manage.go
+++ b/modules/elastic/api/manage.go
@@ -37,6 +37,7 @@ import (
 	"infini.sh/framework/core/queue"
 
 	log "github.com/cihub/seelog"
+	console_common "infini.sh/console/common"
 	"infini.sh/console/core"
 	v1 "infini.sh/console/modules/elastic/api/v1"
 	httprouter "infini.sh/framework/core/api/router"
@@ -60,13 +61,15 @@ func (h *APIHandler) Client() elastic.API {
 }
 
 func (h *APIHandler) HandleCreateClusterAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	var conf = &elastic.ElasticsearchConfig{}
-	err := h.DecodeJSON(req, conf)
+	payload := &elasticConfigPayload{}
+	err := h.DecodeJSON(req, payload)
 	if err != nil {
 		log.Error(err)
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	conf := &payload.ElasticsearchConfig
+	console_common.SetProbePath(conf, payload.ProbePath)
 	conf.Enabled = true
 	if len(conf.Hosts) > 0 && conf.Host == "" {
 		conf.Host = conf.Hosts[0]
@@ -225,6 +228,10 @@ func (h *APIHandler) HandleUpdateClusterAction(w http.ResponseWriter, req *http.
 	newConf := &elastic.ElasticsearchConfig{}
 	json.Unmarshal(confBytes, newConf)
 	newConf.ID = id
+	if probePath, ok := conf["probe_path"]; ok {
+		console_common.SetProbePath(newConf, util.ToString(probePath))
+		delete(conf, "probe_path")
+	}
 
 	if conf["credential_id"] == nil {
 		if newConf.BasicAuth != nil && newConf.BasicAuth.Username != "" {

--- a/modules/elastic/api/test_connection.go
+++ b/modules/elastic/api/test_connection.go
@@ -28,8 +28,10 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"github.com/segmentio/encoding/json"
+	console_common "infini.sh/console/common"
 	"infini.sh/console/core"
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
@@ -47,6 +49,21 @@ type TestAPI struct {
 	core.Handler
 }
 
+const (
+	tryConnectErrorKeyHealthRed           = "cluster.connect.error.health_red"
+	tryConnectErrorKeyNonESEndpoint       = "cluster.connect.error.non_es_endpoint"
+	tryConnectErrorKeyTLSMismatch         = "cluster.connect.error.tls_mismatch"
+	tryConnectErrorKeyAuthRequired        = "cluster.connect.error.auth_required"
+	tryConnectErrorKeyEndpointUnreachable = "cluster.connect.error.endpoint_unreachable"
+	tryConnectErrorKeyUnexpectedStatus    = "cluster.connect.error.unexpected_status"
+	tryConnectErrorKeyDefault             = "cluster.regist.try_connect.failed"
+)
+
+type elasticConfigPayload struct {
+	elastic.ElasticsearchConfig
+	ProbePath string `json:"probe_path,omitempty"`
+}
+
 var testAPI = TestAPI{}
 
 var testInited bool
@@ -59,21 +76,15 @@ func InitTestAPI() {
 }
 
 func (h TestAPI) HandleTestConnectionAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	var (
-		freq    = httpPool.AcquireRequest()
-		fres    = httpPool.AcquireResponse()
-		resBody = map[string]interface{}{}
-	)
-	defer func() {
-		httpPool.ReleaseRequest(freq)
-		httpPool.ReleaseResponse(fres)
-	}()
-	var config = &elastic.ElasticsearchConfig{}
-	err := h.DecodeJSON(req, &config)
+	var resBody = map[string]interface{}{}
+	payload := &elasticConfigPayload{}
+	err := h.DecodeJSON(req, payload)
 	if err != nil {
 		panic(err)
 	}
 	defer req.Body.Close()
+	config := &payload.ElasticsearchConfig
+	console_common.SetProbePath(config, payload.ProbePath)
 	var url string
 	if config.Endpoint != "" {
 		url = config.Endpoint
@@ -123,36 +134,18 @@ func (h TestAPI) HandleTestConnectionAction(w http.ResponseWriter, req *http.Req
 		clusterUUID string
 	)
 	for i, url = range config.Endpoints {
-		if !util.SuffixStr(url, "/") {
-			url = fmt.Sprintf("%s/", url)
-		}
-
-		freq.SetRequestURI(url)
-		freq.Header.SetMethod("GET")
-
-		if config.BasicAuth != nil && strings.TrimSpace(config.BasicAuth.Username) != "" {
-			freq.SetBasicAuth(config.BasicAuth.Username, config.BasicAuth.Password.Get())
-		}
-
-		const testClientName = "elasticsearch_test_connection"
-		err = api.GetFastHttpClient(testClientName).DoTimeout(freq, fres, 10*time.Second)
-
+		clusterInfo, err := console_common.ClusterVersionWithConfig(&elastic.ElasticsearchConfig{
+			Schema:         config.Schema,
+			Endpoint:       url,
+			Endpoints:      []string{url},
+			Distribution:   config.Distribution,
+			BasicAuth:      config.BasicAuth,
+			RequestTimeout: 10,
+			Labels:         config.Labels,
+		})
 		if err != nil {
-			panic(err)
-		}
-
-		var statusCode = fres.StatusCode()
-		if statusCode > 300 || statusCode == 0 {
-			resBody["error"] = fmt.Sprintf("invalid status code: %d", statusCode)
-			h.WriteJSON(w, resBody, 500)
+			writeTryConnectError(h, w, err)
 			return
-		}
-
-		b := fres.Body()
-		clusterInfo := &elastic.ClusterInformation{}
-		err = json.Unmarshal(b, clusterInfo)
-		if err != nil {
-			panic(err)
 		}
 
 		resBody["version"] = clusterInfo.Version.Number
@@ -173,19 +166,9 @@ func (h TestAPI) HandleTestConnectionAction(w http.ResponseWriter, req *http.Req
 			break
 		}
 		//fetch cluster health info
-		freq.SetRequestURI(fmt.Sprintf("%s/_cluster/health", url))
-		fres.Reset()
-		err = api.GetFastHttpClient(testClientName).Do(freq, fres)
+		healthInfo, err := fetchClusterHealth(url, config)
 		if err != nil {
-			resBody["error"] = fmt.Sprintf("error on get cluster health: %v", err)
-			h.WriteJSON(w, resBody, http.StatusInternalServerError)
-			return
-		}
-
-		healthInfo := &elastic.ClusterHealth{}
-		err = json.Unmarshal(fres.Body(), &healthInfo)
-		if err != nil {
-			resBody["error"] = fmt.Sprintf("error on decode cluster health info : %v", err)
+			resBody["error"] = buildTryConnectErrorPayload(err)
 			h.WriteJSON(w, resBody, http.StatusInternalServerError)
 			return
 		}
@@ -195,15 +178,141 @@ func (h TestAPI) HandleTestConnectionAction(w http.ResponseWriter, req *http.Req
 		resBody["active_shards"] = healthInfo.ActiveShards
 
 		if healthInfo.Status == "red" {
-			resBody["error"] = "cluster health status is red, please fix the cluster before connecting"
+			resBody["error"] = buildTryConnectErrorPayload(errors.New("cluster health status is red, please fix the cluster before connecting"))
 			h.WriteJSON(w, resBody, http.StatusInternalServerError)
 			return
 		}
-
-		freq.Reset()
-		fres.Reset()
 	}
 
 	h.WriteJSON(w, resBody, http.StatusOK)
 
+}
+
+func writeTryConnectError(h TestAPI, w http.ResponseWriter, err error) {
+	h.WriteJSON(w, map[string]interface{}{
+		"error": buildTryConnectErrorPayload(err),
+	}, http.StatusInternalServerError)
+}
+
+func buildTryConnectErrorPayload(err error) map[string]interface{} {
+	reason, key := resolveTryConnectError(err)
+	return map[string]interface{}{
+		"reason": reason,
+		"key":    key,
+	}
+}
+
+func sanitizeTryConnectError(err error) string {
+	reason, _ := resolveTryConnectError(err)
+	return reason
+}
+
+func sanitizeTryConnectErrorKey(err error) string {
+	_, key := resolveTryConnectError(err)
+	return key
+}
+
+func resolveTryConnectError(err error) (string, string) {
+	raw := extractTryConnectReason(err)
+	lowerRaw := strings.ToLower(raw)
+
+	switch {
+	case strings.Contains(lowerRaw, "cluster health status is red"):
+		return "cluster health status is red, please fix the cluster before connecting", tryConnectErrorKeyHealthRed
+	case strings.Contains(lowerRaw, "invalid character '<' looking for beginning of value"),
+		strings.Contains(lowerRaw, "<!doctype html>"),
+		strings.Contains(lowerRaw, "<html"):
+		return "the endpoint did not return an Elasticsearch-compatible API response, please check the address and port", tryConnectErrorKeyNonESEndpoint
+	case strings.Contains(lowerRaw, "client sent an http request to an https server"),
+		strings.Contains(lowerRaw, "server gave http response to https client"),
+		strings.Contains(lowerRaw, "first record does not look like a tls handshake"):
+		return "TLS setting does not match the cluster endpoint, please check whether HTTPS is enabled", tryConnectErrorKeyTLSMismatch
+	case strings.Contains(lowerRaw, "missing authentication information"),
+		strings.Contains(lowerRaw, "security_exception"),
+		strings.Contains(lowerRaw, "unauthorized"),
+		strings.Contains(lowerRaw, "invalid status code: 401"):
+		return "authentication is required or invalid, please check the credential", tryConnectErrorKeyAuthRequired
+	case strings.Contains(lowerRaw, "connection refused"),
+		strings.Contains(lowerRaw, "no such host"),
+		strings.Contains(lowerRaw, "context deadline exceeded"),
+		strings.Contains(lowerRaw, "i/o timeout"),
+		strings.Contains(lowerRaw, "timeout"),
+		strings.Contains(lowerRaw, ": eof"),
+		strings.HasSuffix(lowerRaw, " eof"):
+		return "unable to connect to the cluster endpoint, please check the address, network accessibility, and TLS setting", tryConnectErrorKeyEndpointUnreachable
+	case strings.Contains(lowerRaw, "invalid status code"):
+		return "the cluster endpoint returned an unexpected status, please check the address, TLS setting, and credential", tryConnectErrorKeyUnexpectedStatus
+	default:
+		if raw == "" {
+			return "cluster connection failed, please check the address, TLS setting, and credential", tryConnectErrorKeyDefault
+		}
+		return raw, tryConnectErrorKeyDefault
+	}
+}
+
+func extractTryConnectReason(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	raw := strings.TrimSpace(err.Error())
+	if raw == "" {
+		return raw
+	}
+
+	raw = strings.TrimPrefix(raw, "error on get cluster health: ")
+	if !strings.HasPrefix(raw, "{") {
+		return raw
+	}
+
+	payload := map[string]interface{}{}
+	if json.Unmarshal([]byte(raw), &payload) != nil {
+		return raw
+	}
+
+	if errorObj, ok := payload["error"].(map[string]interface{}); ok {
+		if reason, ok := errorObj["reason"].(string); ok && reason != "" {
+			return reason
+		}
+		if causes, ok := errorObj["root_cause"].([]interface{}); ok {
+			for _, cause := range causes {
+				if m, ok := cause.(map[string]interface{}); ok {
+					if reason, ok := m["reason"].(string); ok && reason != "" {
+						return reason
+					}
+				}
+			}
+		}
+	}
+
+	return raw
+}
+
+func fetchClusterHealth(endpoint string, config *elastic.ElasticsearchConfig) (*elastic.ClusterHealth, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := util.Request{
+		Method:  http.MethodGet,
+		Url:     console_common.BuildEndpointWithPath(endpoint, "/_cluster/health"),
+		Context: ctx,
+	}
+	if config.BasicAuth != nil && strings.TrimSpace(config.BasicAuth.Username) != "" {
+		req.SetBasicAuth(config.BasicAuth.Username, config.BasicAuth.Password.Get())
+	}
+
+	res, err := util.ExecuteRequestWithCatchFlag(nil, &req, true)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode > 300 || res.StatusCode == 0 {
+		return nil, errors.New(fmt.Sprintf("invalid status code: %d", res.StatusCode))
+	}
+
+	healthInfo := &elastic.ClusterHealth{}
+	err = json.Unmarshal(res.Body, healthInfo)
+	if err != nil {
+		return nil, err
+	}
+	return healthInfo, nil
 }

--- a/modules/elastic/api/test_connection_test.go
+++ b/modules/elastic/api/test_connection_test.go
@@ -1,0 +1,98 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSanitizeTryConnectError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "connection refused",
+			err:  errors.New(`Get "https://127.0.0.1:9200": dial tcp 127.0.0.1:9200: connect: connection refused`),
+			want: "unable to connect to the cluster endpoint, please check the address, network accessibility, and TLS setting",
+		},
+		{
+			name: "tls mismatch",
+			err:  errors.New(`Get "https://127.0.0.1:9200": http: server gave HTTP response to HTTPS client`),
+			want: "TLS setting does not match the cluster endpoint, please check whether HTTPS is enabled",
+		},
+		{
+			name: "security exception json",
+			err:  errors.New(`{"error":{"root_cause":[{"type":"security_exception","reason":"Missing authentication information for REST request [/]"}],"type":"security_exception","reason":"Missing authentication information for REST request [/]"},"status":401}`),
+			want: "authentication is required or invalid, please check the credential",
+		},
+		{
+			name: "html response",
+			err:  errors.New(`json: invalid character '<' looking for beginning of value: <!DOCTYPE html><html lang="en"><head></head><body></body></html>`),
+			want: "the endpoint did not return an Elasticsearch-compatible API response, please check the address and port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeTryConnectError(tt.err); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSanitizeTryConnectErrorKey(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "connection refused",
+			err:  errors.New(`Get "https://127.0.0.1:9200": dial tcp 127.0.0.1:9200: connect: connection refused`),
+			want: tryConnectErrorKeyEndpointUnreachable,
+		},
+		{
+			name: "tls mismatch",
+			err:  errors.New(`Get "https://127.0.0.1:9200": http: server gave HTTP response to HTTPS client`),
+			want: tryConnectErrorKeyTLSMismatch,
+		},
+		{
+			name: "html response",
+			err:  errors.New(`json: invalid character '<' looking for beginning of value: <!DOCTYPE html><html lang="en"><head></head><body></body></html>`),
+			want: tryConnectErrorKeyNonESEndpoint,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeTryConnectErrorKey(tt.err); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/web/src/locales/en-US/cluster.js
+++ b/web/src/locales/en-US/cluster.js
@@ -90,6 +90,13 @@ export default {
   "cluster.regist.form.verify.valid.endpoint":
     "Please input a domain name or IP address and port number!",
   "cluster.regist.form.verify.required.endpoint": "Please input endpoint!",
+  "cluster.regist.form.label.probe_path": "Probe Path",
+  "cluster.regist.form.placeholder.probe_path": "/_cluster/health",
+  "cluster.regist.form.toggle.probe_path": "Custom Probe Path",
+  "cluster.regist.form.help.probe_path":
+    "Optional. Leave empty to use the default / probe path. Only needed for special cases such as WAF restrictions.",
+  "cluster.regist.form.verify.valid.probe_path":
+    "Probe path must start with /",
   "cluster.regist.form.verify.required.credential":
     "Please select  Agent credential!",
   "cluster.regist.form.verify.required.agent_credential":
@@ -98,6 +105,20 @@ export default {
     "Please input auth username!",
   "cluster.regist.form.verify.required.auth_password":
     "Please input auth password!",
+  "cluster.regist.try_connect.failed":
+    "Cluster connection failed. Check the endpoint, TLS, and authentication settings.",
+  "cluster.connect.error.health_red":
+    "The target cluster health is red. Console only allows connecting Easysearch clusters when their health is green. Fix the cluster before connecting again.",
+  "cluster.connect.error.tls_mismatch":
+    "The TLS setting does not match the cluster endpoint. Check whether HTTPS should be enabled.",
+  "cluster.connect.error.auth_required":
+    "Authentication is required or the credential is invalid. Check the username, password, or saved credential.",
+  "cluster.connect.error.endpoint_unreachable":
+    "Unable to connect to the cluster endpoint. Check the address, network accessibility, and TLS setting.",
+  "cluster.connect.error.non_es_endpoint":
+    "The endpoint did not return an Elasticsearch-compatible API response. Check that the address and port point to the Elasticsearch API.",
+  "cluster.connect.error.unexpected_status":
+    "The cluster returned an unexpected status. Check the address, TLS setting, and authentication settings.",
   "cluster.regist.form.credential.manual.desc":
     "*The new authentication information will be added to the credential store after saving",
 
@@ -138,7 +159,6 @@ export default {
   "cluster.monitor.topn.area": "Area Metric",
   "cluster.monitor.topn.color": "Color Metric",
   "cluster.monitor.topn.theme": "Theme",
-
   "cluster.monitor.logs.timestamp": "Timestamp",
   "cluster.monitor.logs.type": "Type",
   "cluster.monitor.logs.level": "Level",

--- a/web/src/locales/zh-CN/cluster.js
+++ b/web/src/locales/zh-CN/cluster.js
@@ -84,10 +84,30 @@ export default {
   "cluster.regist.form.verify.required.cluster_name": "请输入集群名称！",
   "cluster.regist.form.verify.valid.endpoint": "请输入域名或 IP 地址和端口号！",
   "cluster.regist.form.verify.required.endpoint": "请输入 endpoint 地址！",
+  "cluster.regist.form.label.probe_path": "检测路径",
+  "cluster.regist.form.placeholder.probe_path": "/_cluster/health",
+  "cluster.regist.form.toggle.probe_path": "自定义检测路径",
+  "cluster.regist.form.help.probe_path":
+    "可选。留空时默认使用 / 进行探测，仅在 WAF 等特殊场景下需要填写。",
+  "cluster.regist.form.verify.valid.probe_path":
+    "检测路径必须以 / 开头！",
   "cluster.regist.form.verify.required.credential": "请选择用户凭据！",
   "cluster.regist.form.verify.required.agent_credential": "请选择 Agent 凭据！",
   "cluster.regist.form.verify.required.auth_username": "请输入授权用户名！",
   "cluster.regist.form.verify.required.auth_password": "请输入授权密码！",
+  "cluster.regist.try_connect.failed": "集群连接失败，请检查地址、TLS 与认证信息。",
+  "cluster.connect.error.health_red":
+    "目标集群当前健康状态为 red，仅允许连接健康状态为 green 的集群，请先修复集群后再连接。",
+  "cluster.connect.error.tls_mismatch":
+    "TLS 设置与集群地址不匹配，请检查是否应该启用 HTTPS。",
+  "cluster.connect.error.auth_required":
+    "集群需要认证，或当前凭据无效，请检查用户名、密码或凭据配置。",
+  "cluster.connect.error.endpoint_unreachable":
+    "无法连接到集群地址，请检查地址、网络连通性以及 TLS 设置。",
+  "cluster.connect.error.non_es_endpoint":
+    "目标地址返回的不是 Elasticsearch 兼容 API 响应，请检查地址和端口是否填写正确。",
+  "cluster.connect.error.unexpected_status":
+    "集群返回了异常状态码，请检查地址、TLS 设置和认证信息。",
   "cluster.regist.form.credential.manual.desc":
     "*新的身份验证信息将在保存后添加到凭据库",
 
@@ -128,7 +148,6 @@ export default {
   "cluster.monitor.topn.area": "面积指标",
   "cluster.monitor.topn.color": "颜色指标",
   "cluster.monitor.topn.theme": "主题",
-
   "cluster.monitor.logs.timestamp": "时间戳",
   "cluster.monitor.logs.type": "类型",
   "cluster.monitor.logs.level": "等级",

--- a/web/src/pages/System/Cluster/Form.js
+++ b/web/src/pages/System/Cluster/Form.js
@@ -20,7 +20,11 @@ import { formatMessage } from "umi/locale";
 import TagEditor from "@/components/infini/TagEditor";
 import MonitorConfigsForm from "./MonitorConfigsForm";
 import MetadataConfigsForm from "./MetadataConfigsForm";
-import { formatConfigsValues } from "./utils";
+import {
+  formatConfigsValues,
+  getClusterProbePath,
+  getClusterConnectErrorMessageFromResponse,
+} from "./utils";
 import CredentialForm from "./CredentialForm";
 import AgentCredentialForm from "./AgentCredentialForm";
 import { MANUAL_VALUE } from "./steps";
@@ -47,6 +51,7 @@ class ClusterForm extends React.Component {
       btnLoading: false,
       btnLoadingAgent: false,
       submitLoading: false,
+      showProbePath: !!getClusterProbePath(props.clusterConfig?.editValue),
     };
   }
 
@@ -99,6 +104,7 @@ class ClusterForm extends React.Component {
           isManual,
           collectMode,
           monitored: editValue?.hasOwnProperty("monitored") ? editValue?.monitored : false,
+          showProbePath: !!getClusterProbePath(editValue),
         });
       }
     });
@@ -158,6 +164,7 @@ class ClusterForm extends React.Component {
         name: values.name,
         host: values.host,
         hosts: values.hosts,
+        probe_path: values.probe_path,
         credential_id:
           values.credential_id !== MANUAL_VALUE
             ? values.credential_id
@@ -273,6 +280,7 @@ class ClusterForm extends React.Component {
             hosts: values.hosts,
 
             schema: values.isTLS === true ? "https" : "http",
+            probe_path: values.probe_path,
           };
           if (type === "agent") {
             newVals = {
@@ -310,7 +318,7 @@ class ClusterForm extends React.Component {
             type: "clusterConfig/doTryConnect",
             payload: newVals,
           });
-          if (res) {
+          if (res && !res.error) {
             message.success(
               formatMessage({
                 id: "app.message.connect.success",
@@ -320,6 +328,13 @@ class ClusterForm extends React.Component {
               version: res.version,
             });
             this.clusterUUID = res.cluster_uuid;
+          } else if (res?.error) {
+            message.error(
+              getClusterConnectErrorMessageFromResponse(
+                res,
+                "cluster.regist.try_connect.failed"
+              )
+            );
           }
           if (type === "agent") {
             this.setState({ btnLoadingAgent: false });
@@ -339,6 +354,17 @@ class ClusterForm extends React.Component {
       }
     }
     // validation passed
+    callback();
+  };
+  validateProbePathRule = (rule, value, callback) => {
+    if (!value) {
+      callback();
+      return;
+    }
+    if (!String(value).trim().startsWith("/")) {
+      callback(formatMessage({ id: "cluster.regist.form.verify.valid.probe_path" }));
+      return;
+    }
     callback();
   };
 
@@ -491,6 +517,47 @@ class ClusterForm extends React.Component {
                   />
                 )}
               </Form.Item>
+              <Form.Item label={formatMessage({ id: "app.action.advanced" })}>
+                <Button
+                  type="link"
+                  style={{ paddingLeft: 0 }}
+                  onClick={() =>
+                    this.setState((st) => ({ showProbePath: !st.showProbePath }))
+                  }
+                >
+                  {formatMessage({
+                    id: this.state.showProbePath
+                      ? "form.button.collapse"
+                      : "cluster.regist.form.toggle.probe_path",
+                  })}
+                </Button>
+              </Form.Item>
+              {this.state.showProbePath ? (
+                <Form.Item
+                  label={formatMessage({
+                    id: "cluster.regist.form.label.probe_path",
+                  })}
+                  extra={formatMessage({
+                    id: "cluster.regist.form.help.probe_path",
+                  })}
+                >
+                  {getFieldDecorator("probe_path", {
+                    initialValue: getClusterProbePath(editValue),
+                    normalize: (value) => (value || "").trim(),
+                    rules: [
+                      {
+                        validator: this.validateProbePathRule,
+                      },
+                    ],
+                  })(
+                    <Input
+                      placeholder={formatMessage({
+                        id: "cluster.regist.form.placeholder.probe_path",
+                      })}
+                    />
+                  )}
+                </Form.Item>
+              ) : null}
               <Form.Item
                 label={formatMessage({
                   id: "cluster.regist.step.connect.label.auth",

--- a/web/src/pages/System/Cluster/Step.js
+++ b/web/src/pages/System/Cluster/Step.js
@@ -1,4 +1,4 @@
-import { Form, Steps, Button, message, Spin, Card, Row, Col } from "antd";
+import { Alert, Form, Steps, Button, message, Spin, Card, Row, Col } from "antd";
 import { connect } from "dva";
 import { useState, useRef, useEffect } from "react";
 import { InitialStep, ExtraStep, ResultStep, MANUAL_VALUE } from "./steps";
@@ -6,6 +6,10 @@ import PageHeaderWrapper from "@/components/PageHeaderWrapper";
 import styles from "./step.less";
 import { formatMessage } from "umi/locale";
 import { formatConfigsValues } from "./utils";
+import {
+  getClusterConnectErrorMessageFromError,
+  getClusterConnectErrorMessageFromResponse,
+} from "./utils";
 import { Link } from "umi";
 import { SearchEngines } from "@/lib/search_engines";
 
@@ -42,6 +46,7 @@ const ClusterStep = ({ dispatch, history, query }) => {
     isLoading: false,
     current: 0,
   });
+  const [connectError, setConnectError] = useState();
   const changeStep = (step) => {
     setState((st) => {
       return {
@@ -65,6 +70,7 @@ const ClusterStep = ({ dispatch, history, query }) => {
   const createFormPromise = (type, formatPayload, callback) => {
     return new Promise((resolve, reject) => {
       setIsLoading(true);
+      setConnectError(undefined);
       formRef.current.validateFields((errors, values) => {
         if (errors) {
           resolve(false);
@@ -82,12 +88,25 @@ const ClusterStep = ({ dispatch, history, query }) => {
               }
               resolve(true);
             } else {
+              setConnectError(
+                getClusterConnectErrorMessageFromResponse(
+                  res,
+                  "cluster.regist.try_connect.failed"
+                )
+              );
               resolve(false);
               setIsLoading(false);
             }
           })
-          .catch((err) => {
+          .catch(async (err) => {
+            setConnectError(
+              await getClusterConnectErrorMessageFromError(
+                err,
+                "cluster.regist.try_connect.failed"
+              )
+            );
             setIsLoading(false);
+            resolve(false);
           });
       });
     });
@@ -109,6 +128,7 @@ const ClusterStep = ({ dispatch, history, query }) => {
               ? values.credential_id
               : undefined,
           schema: values.isTLS === true ? "https" : "http",
+          probe_path: values.probe_path,
         }),
         (values, res) => {
           setClusterConfig({
@@ -143,6 +163,7 @@ const ClusterStep = ({ dispatch, history, query }) => {
             distribution: clusterConfig.distribution,
             host: clusterConfig.host,
             hosts: clusterConfig.hosts,
+            probe_path: clusterConfig.probe_path,
             location: clusterConfig.location,
             credential_id:
               clusterConfig.credential_id !== MANUAL_VALUE
@@ -241,6 +262,14 @@ const ClusterStep = ({ dispatch, history, query }) => {
                 ))}
               </Steps>
               <div className="steps-content">{renderContent(current)}</div>
+              {current === 0 && connectError ? (
+                <Alert
+                  style={{ marginBottom: 16 }}
+                  type="error"
+                  showIcon
+                  message={connectError}
+                />
+              ) : null}
               <Form
                 {...{
                   labelCol: {

--- a/web/src/pages/System/Cluster/steps/extra_step.js
+++ b/web/src/pages/System/Cluster/steps/extra_step.js
@@ -16,6 +16,7 @@ import MetadataConfigsForm from "../MetadataConfigsForm";
 import "../Form.scss";
 import AgentCredentialForm from "../AgentCredentialForm";
 import { MANUAL_VALUE } from "./initial_step";
+import { getClusterConnectErrorMessageFromResponse } from "../utils";
 
 @Form.create()
 export class ExtraStep extends React.Component {
@@ -66,6 +67,7 @@ export class ExtraStep extends React.Component {
           let newVals = {
             hosts: initialValue?.hosts || [],
             schema: initialValue.isTLS === true ? "https" : "http",
+            probe_path: initialValue?.probe_path,
           };
           newVals = {
             ...newVals,
@@ -86,11 +88,18 @@ export class ExtraStep extends React.Component {
             type: "clusterConfig/doTryConnect",
             payload: newVals,
           });
-          if (res) {
+          if (res && !res.error) {
             message.success(
               formatMessage({
                 id: "app.message.connect.success",
               })
+            );
+          } else if (res?.error) {
+            message.error(
+              getClusterConnectErrorMessageFromResponse(
+                res,
+                "cluster.regist.try_connect.failed"
+              )
             );
           }
           this.setState({ btnLoadingAgent: false });

--- a/web/src/pages/System/Cluster/steps/initial_step.js
+++ b/web/src/pages/System/Cluster/steps/initial_step.js
@@ -1,4 +1,4 @@
-import { Form, Input, Switch, Icon, Select } from "antd";
+import { Form, Input, Switch, Icon, Select, Button } from "antd";
 import { formatMessage } from "umi/locale";
 import CredentialForm from "../CredentialForm";
 import "../Form.scss";
@@ -15,7 +15,8 @@ export class InitialStep extends React.Component {
     this.state = {
       needAuth: props.initialValue?.isAuth !== undefined,
       isManual: props.initialValue?.credential_id === MANUAL_VALUE,
-      isPageTLS: isTLS(props.initialValue?.host)
+      isPageTLS: isTLS(props.initialValue?.host),
+      showProbePath: !!props.initialValue?.probe_path,
     };
   }
   handleAuthChange = (val) => {
@@ -48,6 +49,17 @@ export class InitialStep extends React.Component {
       }
     }
     // validation passed
+    callback();
+  };
+  validateProbePathRule = (rule, value, callback) => {
+    if (!value) {
+      callback();
+      return;
+    }
+    if (!String(value).trim().startsWith("/")) {
+      callback(formatMessage({ id: "cluster.regist.form.verify.valid.probe_path" }));
+      return;
+    }
     callback();
   };
   render() {
@@ -136,6 +148,47 @@ export class InitialStep extends React.Component {
             />
           )}
         </Form.Item>
+        <Form.Item label={formatMessage({ id: "app.action.advanced" })}>
+          <Button
+            type="link"
+            style={{ paddingLeft: 0 }}
+            onClick={() =>
+              this.setState((st) => ({ showProbePath: !st.showProbePath }))
+            }
+          >
+            {formatMessage({
+              id: this.state.showProbePath
+                ? "form.button.collapse"
+                : "cluster.regist.form.toggle.probe_path",
+            })}
+          </Button>
+        </Form.Item>
+        {this.state.showProbePath ? (
+          <Form.Item
+            label={formatMessage({
+              id: "cluster.regist.form.label.probe_path",
+            })}
+            extra={formatMessage({
+              id: "cluster.regist.form.help.probe_path",
+            })}
+          >
+            {getFieldDecorator("probe_path", {
+              initialValue: initialValue?.probe_path || "",
+              normalize: (value) => (value || "").trim(),
+              rules: [
+                {
+                  validator: this.validateProbePathRule,
+                },
+              ],
+            })(
+              <Input
+                placeholder={formatMessage({
+                  id: "cluster.regist.form.placeholder.probe_path",
+                })}
+              />
+            )}
+          </Form.Item>
+        ) : null}
         <Form.Item
           label={formatMessage({
             id: "cluster.regist.step.connect.label.auth",

--- a/web/src/pages/System/Cluster/utils.js
+++ b/web/src/pages/System/Cluster/utils.js
@@ -1,3 +1,5 @@
+import { formatMessage } from "umi/locale";
+
 export const formatConfigsValues = (configs) => {
   const configs_new = {};
   Object.keys(configs).map((k) => {
@@ -11,4 +13,140 @@ export const formatConfigsValues = (configs) => {
     };
   });
   return configs_new;
+};
+
+export const getClusterProbePath = (cluster) =>
+  cluster?.probe_path || cluster?.labels?.console_probe_path || "";
+
+const normalizeReason = (reason) => `${reason || ""}`.trim();
+
+const resolveClusterConnectErrorMessageByKey = (key) => {
+  if (!key || !String(key).startsWith("cluster.")) {
+    return "";
+  }
+  return formatMessage({ id: key });
+};
+
+const extractStructuredReason = (reason) => {
+  const normalized = normalizeReason(reason);
+  if (!normalized.startsWith("{")) {
+    return normalized;
+  }
+  try {
+    const payload = JSON.parse(normalized);
+    return (
+      payload?.error?.reason ||
+      payload?.error?.root_cause?.[0]?.reason ||
+      normalized
+    );
+  } catch (e) {
+    return normalized;
+  }
+};
+
+export const getClusterConnectErrorMessage = (
+  reason,
+  fallbackId = "guide.cluster.test.connection.failed"
+) => {
+  const normalizedReason = extractStructuredReason(reason).replace(
+    /^error on get cluster health:\s*/i,
+    ""
+  );
+  const lowerReason = normalizedReason.toLowerCase();
+  if (!normalizedReason) {
+    return formatMessage({ id: fallbackId });
+  }
+
+  if (normalizedReason.includes("cluster health status is red")) {
+    return formatMessage({ id: "cluster.connect.error.health_red" });
+  }
+
+  if (
+    lowerReason.includes("invalid character '<' looking for beginning of value") ||
+    lowerReason.includes("<!doctype html>") ||
+    lowerReason.includes("<html")
+  ) {
+    return formatMessage({ id: "cluster.connect.error.non_es_endpoint" });
+  }
+
+  if (
+    lowerReason.includes("client sent an http request to an https server") ||
+    lowerReason.includes("server gave http response to https client") ||
+    lowerReason.includes("first record does not look like a tls handshake")
+  ) {
+    return formatMessage({ id: "cluster.connect.error.tls_mismatch" });
+  }
+
+  if (
+    lowerReason.includes("missing authentication information") ||
+    lowerReason.includes("security_exception") ||
+    lowerReason.includes("unauthorized") ||
+    lowerReason.includes("invalid status code: 401")
+  ) {
+    return formatMessage({ id: "cluster.connect.error.auth_required" });
+  }
+
+  if (
+    lowerReason.includes("connection refused") ||
+    lowerReason.includes("no such host") ||
+    lowerReason.includes("context deadline exceeded") ||
+    lowerReason.includes("i/o timeout") ||
+    lowerReason.includes("timeout") ||
+    lowerReason.includes(": eof") ||
+    lowerReason.endsWith(" eof")
+  ) {
+    return formatMessage({ id: "cluster.connect.error.endpoint_unreachable" });
+  }
+
+  if (lowerReason.includes("invalid status code")) {
+    return formatMessage({ id: "cluster.connect.error.unexpected_status" });
+  }
+
+  return normalizedReason;
+};
+
+export const getClusterConnectErrorMessageFromResponse = (
+  response,
+  fallbackId = "guide.cluster.test.connection.failed"
+) => {
+  const key =
+    typeof response?.error === "string" ? "" : response?.error?.key || "";
+  const localizedMessage = resolveClusterConnectErrorMessageByKey(key);
+  if (localizedMessage) {
+    return localizedMessage;
+  }
+  const reason =
+    typeof response?.error === "string"
+      ? response.error
+      : response?.error?.reason;
+  return getClusterConnectErrorMessage(reason, fallbackId);
+};
+
+export const getClusterConnectErrorMessageFromError = async (
+  error,
+  fallbackId = "guide.cluster.test.connection.failed"
+) => {
+  let key =
+    (typeof error?.error === "string" ? "" : error?.error?.key) || "";
+  let reason =
+    (typeof error?.error === "string" ? error.error : error?.error?.reason) ||
+    "";
+
+  if (!reason && error?.rawResponse?.clone) {
+    try {
+      const payload = await error.rawResponse.clone().json();
+      key = typeof payload?.error === "string" ? "" : payload?.error?.key || key;
+      reason =
+        typeof payload?.error === "string"
+          ? payload.error
+          : payload?.error?.reason || "";
+    } catch (e) {}
+  }
+
+  const localizedMessage = resolveClusterConnectErrorMessageByKey(key);
+  if (localizedMessage) {
+    return localizedMessage;
+  }
+
+  return getClusterConnectErrorMessage(reason, fallbackId);
 };


### PR DESCRIPTION
## Summary
- store custom cluster probe paths in Console-managed labels and reuse them during connection checks
- allow cluster create/edit flows to configure probe_path from an advanced section
- normalize cluster connection failures into user-facing localized error messages

## Testing
- go test ./common ./modules/elastic/api
- NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' ./node_modules/.bin/umi build