### PR TITLE
improve: configure setup template shards and replicas

### DIFF
--- a/config/setup/easysearch/template_ilm.tpl
+++ b/config/setup/easysearch/template_ilm.tpl
@@ -24,7 +24,8 @@ PUT _template/$[[SETUP_TEMPLATE_NAME]]
         },
         "codec": "ZSTD",
         "source_reuse": false,
-        "number_of_shards": "1"
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]"
       }
     },
     "mappings": {
@@ -171,7 +172,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]metrics-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": true,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "mapping.coerce": false,
         "mapping.ignore_malformed": true
@@ -240,7 +242,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]logs-rollover
       },
       "codec": "ZSTD",
       "source_reuse": false,
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -299,7 +302,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]requests_logging-rollover
       },
       "codec": "ZSTD",
       "source_reuse": true,
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -369,7 +373,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]async_bulk_results-rollover
       },
       "codec": "ZSTD",
       "source_reuse": false,
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -439,7 +444,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]alert-history-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": false,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -606,7 +612,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]activities-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": false,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -711,7 +718,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]audit-logs-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": false,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {

--- a/config/setup/easysearch/template_ilm_1_12_1.tpl
+++ b/config/setup/easysearch/template_ilm_1_12_1.tpl
@@ -24,7 +24,8 @@ PUT _template/$[[SETUP_TEMPLATE_NAME]]
         },
         "codec": "ZSTD",
         "source_reuse": false,
-        "number_of_shards": "1"
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]"
       }
     },
     "mappings": {
@@ -110,7 +111,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]metrics-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": false,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "mapping.coerce": false,
         "mapping.ignore_malformed": true
@@ -197,7 +199,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]logs-rollover
       },
       "codec": "ZSTD",
       "source_reuse": false,
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -256,7 +259,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]requests_logging-rollover
       },
       "codec": "ZSTD",
       "source_reuse": true,
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -326,7 +330,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]async_bulk_results-rollover
       },
       "codec": "ZSTD",
       "source_reuse": false,
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -396,7 +401,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]alert-history-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": false,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -563,7 +569,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]activities-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": false,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -668,7 +675,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]audit-logs-rollover
         },
         "codec" : "ZSTD",
         "source_reuse": false,
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {

--- a/config/setup/easysearch/template_rollup.tpl
+++ b/config/setup/easysearch/template_rollup.tpl
@@ -6,7 +6,7 @@ PUT /_rollup/jobs/rollup_index_stats
     "target_index": "rollup_index_stats_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 600,
+    "page_size": 100,
     "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
@@ -51,7 +51,7 @@ PUT /_rollup/jobs/rollup_index_health
     "target_index": "rollup_index_health_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 600,
+    "page_size": 100,
     "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
@@ -90,7 +90,7 @@ PUT /_rollup/jobs/rollup_cluster_stats
   "rollup": {
     "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_cluster_stats_{{ctx.source_index}}",
-    "page_size": 600,
+    "page_size": 100,
     "continuous": true,
     "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
@@ -132,7 +132,7 @@ PUT /_rollup/jobs/rollup_cluster_health
     "source_index": "$[[SETUP_INDEX_PREFIX]]metrics",
     "target_index": "rollup_cluster_health_{{ctx.source_index}}",
     "continuous": true,
-    "page_size": 600,
+    "page_size": 100,
     "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
@@ -173,7 +173,7 @@ PUT /_rollup/jobs/rollup_node_stats
     "target_index": "rollup_node_stats_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 600,
+    "page_size": 100,
     "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
@@ -256,7 +256,7 @@ PUT /_rollup/jobs/rollup_shard_stats_metrics
     "target_index": "rollup_shard_stats_metrics_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 600,
+    "page_size": 100,
     "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
@@ -302,7 +302,7 @@ PUT /_rollup/jobs/rollup_shard_stats_state
     "target_index": "rollup_shard_stats_state_{{ctx.source_index}}",
     "timestamp": "timestamp",
     "continuous": true,
-    "page_size": 600,
+    "page_size": 100,
     "cron": "*/5 0-23 * * *",
     "timezone": "UTC",
     "stats": [
@@ -375,7 +375,8 @@ PUT _template/rollup_policy_template
   "order": 1, 
   "index_patterns": ["rollup*"],
   "settings": {
-    "index.lifecycle.name": "ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention"
+    "index.lifecycle.name": "ilm_$[[SETUP_INDEX_PREFIX]]rollup-30days-retention",
+    "index.auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]"
   }
 }
 

--- a/config/setup/elasticsearch/template_ilm.tpl
+++ b/config/setup/elasticsearch/template_ilm.tpl
@@ -23,7 +23,8 @@ PUT _template/$[[SETUP_TEMPLATE_NAME]]
             }
           }
         },
-        "number_of_shards": "1"
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]"
       }
     },
     "mappings": {
@@ -105,7 +106,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]metrics-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]metrics"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "mapping.coerce": false,
         "mapping.ignore_malformed": true
@@ -173,7 +175,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]logs-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]logs"
       },
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -231,7 +234,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]requests_logging-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]requests_logging"
       },
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -300,7 +304,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]async_bulk_results-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]async_bulk_results"
       },
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -369,7 +374,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]alert-history-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]alert-history"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
          "analysis": {
           "analyzer": {
@@ -534,7 +540,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]activities-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]activities"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -638,7 +645,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]audit-logs-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]audit-logs"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async"
       }
     },

--- a/config/setup/elasticsearch/v5/template_ilm.tpl
+++ b/config/setup/elasticsearch/v5/template_ilm.tpl
@@ -21,7 +21,8 @@ PUT _template/$[[SETUP_TEMPLATE_NAME]]
           }
         }
       },
-      "number_of_shards": "1"
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]"
     }
   },
   "mappings": {
@@ -59,7 +60,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]metrics-rollover
     "index" : {
       "format" : "7",
       "codec" : "best_compression",
-      "number_of_shards" : "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog.durability":"async"
     }
   },
@@ -121,7 +123,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]logs-rollover
     "index": {
       "format": "7",
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -174,7 +177,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]requests_logging-rollover
     "index": {
       "format": "7",
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -238,7 +242,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]async_bulk_results-rollover
     "index": {
       "format": "7",
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -302,7 +307,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]alert-history-rollover
       "index" : {
         "format" : "7",
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -457,7 +463,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]activities-rollover
       "index" : {
         "format" : "7",
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -556,7 +563,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]audit-logs-rollover
       "index" : {
         "format" : "7",
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {

--- a/config/setup/elasticsearch/v6/template_ilm.tpl
+++ b/config/setup/elasticsearch/v6/template_ilm.tpl
@@ -23,7 +23,8 @@ PUT _template/$[[SETUP_TEMPLATE_NAME]]
           }
         }
       },
-      "number_of_shards": "1"
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]"
     }
   },
   "mappings": {
@@ -94,7 +95,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]metrics-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]metrics"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async"
       }
     },
@@ -164,7 +166,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]logs-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]logs"
       },
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -224,7 +227,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]requests_logging-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]requests_logging"
       },
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -295,7 +299,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]async_bulk_results-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]async_bulk_results"
       },
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -366,7 +371,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]alert-history-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]alert-history"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -533,7 +539,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]activities-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]activities"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {
@@ -639,7 +646,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]audit-logs-rollover
           "rollover_alias" : "$[[SETUP_INDEX_PREFIX]]audit-logs"
         },
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async",
         "analysis": {
           "analyzer": {

--- a/config/setup/opensearch/template_ilm.tpl
+++ b/config/setup/opensearch/template_ilm.tpl
@@ -23,7 +23,8 @@ PUT _template/$[[SETUP_TEMPLATE_NAME]]
           }
         }
       },
-      "number_of_shards": "1"
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]"
     }
   },
   "mappings": {
@@ -117,7 +118,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]metrics-rollover
    "settings": {
     "index":{
         "codec" : "best_compression",
-        "number_of_shards" : "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog.durability":"async"
     },
     "plugins.index_state_management.rollover_alias": "$[[SETUP_INDEX_PREFIX]]metrics"
@@ -167,7 +169,8 @@ PUT /_template/$[[SETUP_INDEX_PREFIX]]logs-rollover
     "settings": {
       "plugins.index_state_management.rollover_alias": "$[[SETUP_INDEX_PREFIX]]logs",
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -222,7 +225,8 @@ PUT _template/$[[SETUP_INDEX_PREFIX]]requests_logging-rollover
     "settings": {
       "plugins.index_state_management.rollover_alias": "$[[SETUP_INDEX_PREFIX]]requests_logging",
       "codec": "best_compression",
-      "number_of_shards": "1",
+      "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+      "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
       "translog": {
         "durability": "async"
       }
@@ -288,7 +292,8 @@ PUT /_template/$[[SETUP_INDEX_PREFIX]]async_bulk_results-rollover
       "settings": {
         "plugins.index_state_management.rollover_alias": "$[[SETUP_INDEX_PREFIX]]async_bulk_results",
         "codec": "best_compression",
-        "number_of_shards": "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog": {
           "durability": "async"
         }
@@ -353,7 +358,8 @@ PUT /_template/$[[SETUP_INDEX_PREFIX]]alert-history-rollover
       "settings": {
         "plugins.index_state_management.rollover_alias": "$[[SETUP_INDEX_PREFIX]]alert-history",
         "codec": "best_compression",
-        "number_of_shards": "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog": {
           "durability": "async"
         },
@@ -516,7 +522,8 @@ PUT /_template/$[[SETUP_INDEX_PREFIX]]activities-rollover
       "settings": {
         "plugins.index_state_management.rollover_alias": "$[[SETUP_INDEX_PREFIX]]activities",
         "codec": "best_compression",
-        "number_of_shards": "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog": {
           "durability": "async"
         },
@@ -620,7 +627,8 @@ PUT /_template/$[[SETUP_INDEX_PREFIX]]audit-logs-rollover
       "settings": {
         "plugins.index_state_management.rollover_alias": "$[[SETUP_INDEX_PREFIX]]audit-logs",
         "codec": "best_compression",
-        "number_of_shards": "1",
+        "number_of_shards": "$[[SETUP_PRIMARY_SHARDS]]",
+        "auto_expand_replicas": "$[[SETUP_AUTO_EXPAND_REPLICAS]]",
         "translog": {
           "durability": "async"
         },

--- a/plugin/setup/setup.go
+++ b/plugin/setup/setup.go
@@ -35,7 +35,9 @@ import (
 	"net/http"
 	uri2 "net/url"
 	"path"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -158,6 +160,8 @@ type SetupRequest struct {
 	BootstrapPassword  string `json:"bootstrap_password"`
 	CredentialSecret   string `json:"credential_secret"`
 	InitializeTemplate string `json:"initialize_template"`
+	PrimaryShards      int    `json:"primary_shards"`
+	AutoExpandReplicas string `json:"auto_expand_replicas"`
 }
 
 var GlobalSystemElasticsearchID = "infini_default_system_cluster"
@@ -168,6 +172,40 @@ const TemplateExists = "elasticsearch_template_exists"
 const VersionNotSupport = "unknown_cluster_version"
 
 var cfg1 elastic1.ORMConfig
+
+const defaultSetupAutoExpandReplicas = "0-1"
+
+var setupAutoExpandReplicasPattern = regexp.MustCompile(`^(false|all|\d+-\d+)$`)
+
+func resolveSetupTemplateSettings(client elastic.API, request *SetupRequest) (int, string, error) {
+	primaryShards := request.PrimaryShards
+	if primaryShards <= 0 {
+		health, err := client.ClusterHealth(context.Background())
+		if err != nil {
+			return 0, "", err
+		}
+		if health != nil {
+			if health.NumberOf_data_nodes > 0 {
+				primaryShards = health.NumberOf_data_nodes
+			} else if health.NumberOfNodes > 0 {
+				primaryShards = health.NumberOfNodes
+			}
+		}
+	}
+	if primaryShards <= 0 {
+		primaryShards = 1
+	}
+
+	autoExpandReplicas := strings.TrimSpace(request.AutoExpandReplicas)
+	if autoExpandReplicas == "" {
+		autoExpandReplicas = defaultSetupAutoExpandReplicas
+	}
+	if !setupAutoExpandReplicasPattern.MatchString(autoExpandReplicas) {
+		return 0, "", errors.Errorf("invalid auto expand replicas, expected false, all, or a range like 0-1")
+	}
+
+	return primaryShards, autoExpandReplicas, nil
+}
 
 // validate checks the Elasticsearch cluster configuration and validates the setup.
 func (module *Module) validate(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -889,6 +927,11 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 		break
 	}
 
+	primaryShards, autoExpandReplicas, err := resolveSetupTemplateSettings(elastic.GetClient(GlobalSystemElasticsearchID), request)
+	if err != nil {
+		panic(err)
+	}
+
 	dslTplFile := path.Join(baseDir, dslTplFileName)
 	if !util.FileExists(dslTplFile) {
 		panic(errors.Errorf("template file %v for setup was missing", dslTplFile))
@@ -975,6 +1018,10 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 			return w.Write([]byte(request.BootstrapUsername))
 		case "SETUP_DOC_TYPE":
 			return w.Write([]byte(docType))
+		case "SETUP_PRIMARY_SHARDS":
+			return w.Write([]byte(strconv.Itoa(primaryShards)))
+		case "SETUP_AUTO_EXPAND_REPLICAS":
+			return w.Write([]byte(autoExpandReplicas))
 		}
 		//ignore unresolved variable
 		return w.Write([]byte("$[[" + tag + "]]"))

--- a/plugin/setup/template_settings_test.go
+++ b/plugin/setup/template_settings_test.go
@@ -1,0 +1,46 @@
+package task
+
+import "testing"
+
+func TestResolveSetupTemplateSettingsUsesProvidedValues(t *testing.T) {
+	request := &SetupRequest{
+		PrimaryShards:      3,
+		AutoExpandReplicas: "0-2",
+	}
+
+	primaryShards, autoExpandReplicas, err := resolveSetupTemplateSettings(nil, request)
+	if err != nil {
+		t.Fatalf("resolveSetupTemplateSettings returned error: %v", err)
+	}
+	if primaryShards != 3 {
+		t.Fatalf("expected primary shards 3, got %d", primaryShards)
+	}
+	if autoExpandReplicas != "0-2" {
+		t.Fatalf("expected auto expand replicas 0-2, got %s", autoExpandReplicas)
+	}
+}
+
+func TestResolveSetupTemplateSettingsUsesDefaultAutoExpandReplicas(t *testing.T) {
+	request := &SetupRequest{
+		PrimaryShards: 2,
+	}
+
+	_, autoExpandReplicas, err := resolveSetupTemplateSettings(nil, request)
+	if err != nil {
+		t.Fatalf("resolveSetupTemplateSettings returned error: %v", err)
+	}
+	if autoExpandReplicas != defaultSetupAutoExpandReplicas {
+		t.Fatalf("expected default auto expand replicas %s, got %s", defaultSetupAutoExpandReplicas, autoExpandReplicas)
+	}
+}
+
+func TestResolveSetupTemplateSettingsRejectsInvalidAutoExpandReplicas(t *testing.T) {
+	request := &SetupRequest{
+		PrimaryShards:      1,
+		AutoExpandReplicas: "bad-value",
+	}
+
+	if _, _, err := resolveSetupTemplateSettings(nil, request); err == nil {
+		t.Fatal("expected invalid auto expand replicas to return an error")
+	}
+}


### PR DESCRIPTION
## Summary
- allow setup requests to provide primary shard and auto-expand replica settings
- apply those settings across Elasticsearch, OpenSearch, and Easysearch setup templates
- tune Easysearch rollup template initialization for the newer rollup path

## Testing
- go test ./plugin/setup