### PR TITLE
feat: enforce https and replay protection for sensitive requests

### DIFF
--- a/core/auth.go
+++ b/core/auth.go
@@ -34,6 +34,7 @@ import (
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/util"
 	"net/http"
+	"strings"
 )
 
 // Handler is the object of http handler
@@ -92,6 +93,82 @@ func (handler Handler) RequirePermission(h httprouter.Handle, permissions ...str
 
 		h(w, r, ps)
 	}
+}
+
+func RequestUsesSecureTransport(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	if req.TLS != nil {
+		return true
+	}
+
+	for _, header := range []string{"X-Forwarded-Proto", "X-Forwarded-Protocol", "X-Url-Scheme"} {
+		if headerIndicatesHTTPS(req.Header.Get(header)) {
+			return true
+		}
+	}
+
+	if strings.EqualFold(strings.TrimSpace(req.Header.Get("X-Forwarded-Ssl")), "on") {
+		return true
+	}
+
+	return forwardedHeaderIndicatesHTTPS(req.Header.Get("Forwarded"))
+}
+
+func (handler Handler) RequireSecureTransport(h httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if !RequestUsesSecureTransport(r) {
+			handler.WriteError(w, "sensitive endpoints require HTTPS or a trusted HTTPS reverse proxy", http.StatusUpgradeRequired)
+			return
+		}
+		h(w, r, ps)
+	}
+}
+
+func RequireSecureTransport(h httprouter.Handle) httprouter.Handle {
+	return Handler{}.RequireSecureTransport(h)
+}
+
+func (handler Handler) RequireReplayProtection(h httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if err := ValidateAndConsumeReplayNonce(r); err != nil {
+			handler.WriteError(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+		h(w, r, ps)
+	}
+}
+
+func RequireReplayProtection(h httprouter.Handle) httprouter.Handle {
+	return Handler{}.RequireReplayProtection(h)
+}
+
+func headerIndicatesHTTPS(value string) bool {
+	if value == "" {
+		return false
+	}
+	first := strings.TrimSpace(strings.Split(value, ",")[0])
+	return strings.EqualFold(first, "https")
+}
+
+func forwardedHeaderIndicatesHTTPS(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	for _, forwardedValue := range strings.Split(value, ",") {
+		for _, token := range strings.Split(forwardedValue, ";") {
+			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
+			if len(parts) != 2 || !strings.EqualFold(parts[0], "proto") {
+				continue
+			}
+			proto := strings.Trim(parts[1], "\"")
+			return strings.EqualFold(proto, "https")
+		}
+	}
+
+	return false
 }
 
 func (handler Handler) RequireClusterPermission(h httprouter.Handle, permissions ...string) httprouter.Handle {

--- a/core/auth_test.go
+++ b/core/auth_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
+)
+
+func TestRequestUsesSecureTransport(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(req *http.Request)
+		secure bool
+	}{
+		{
+			name: "tls request",
+			setup: func(req *http.Request) {
+				req.TLS = &tls.ConnectionState{}
+			},
+			secure: true,
+		},
+		{
+			name: "forwarded proto",
+			setup: func(req *http.Request) {
+				req.Header.Set("X-Forwarded-Proto", "https")
+			},
+			secure: true,
+		},
+		{
+			name: "forwarded header",
+			setup: func(req *http.Request) {
+				req.Header.Set("Forwarded", `for=127.0.0.1;proto=https;host=console.local`)
+			},
+			secure: true,
+		},
+		{
+			name: "plain http",
+			setup: func(req *http.Request) {
+			},
+			secure: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://console.local/account/login", nil)
+			tt.setup(req)
+
+			if RequestUsesSecureTransport(req) != tt.secure {
+				t.Fatalf("expected secure=%v", tt.secure)
+			}
+		})
+	}
+}
+
+func TestRequireSecureTransport(t *testing.T) {
+	handler := Handler{}
+	called := false
+	protected := handler.RequireSecureTransport(func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://console.local/account/login", nil)
+	resp := httptest.NewRecorder()
+
+	protected(resp, req, nil)
+
+	if called {
+		t.Fatal("expected insecure request to be blocked")
+	}
+	if resp.Code != http.StatusUpgradeRequired {
+		t.Fatalf("expected status %d, got %d", http.StatusUpgradeRequired, resp.Code)
+	}
+}

--- a/core/replay.go
+++ b/core/replay.go
@@ -1,0 +1,161 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	pathutil "path"
+	"strings"
+	"sync"
+	"time"
+
+	"infini.sh/framework/core/util"
+)
+
+const replayNonceHeader = "X-Request-Nonce"
+const replayNonceTTL = 30 * time.Second
+
+type replayNonceRecord struct {
+	Subject   string
+	Method    string
+	Path      string
+	ExpiresAt time.Time
+}
+
+type replayNonceStore struct {
+	mu      sync.Mutex
+	records map[string]replayNonceRecord
+}
+
+var sensitiveRequestNonceStore = replayNonceStore{
+	records: map[string]replayNonceRecord{},
+}
+
+func IssueReplayNonce(r *http.Request, method, requestPath string) (string, time.Duration, error) {
+	normalizedMethod, normalizedPath, err := normalizeReplayScope(method, requestPath)
+	if err != nil {
+		return "", 0, err
+	}
+
+	nonce := util.GenerateSecureString(32)
+	if nonce == "" {
+		return "", 0, fmt.Errorf("failed to generate replay nonce")
+	}
+
+	subject := replayRequestSubject(r)
+	expiresAt := time.Now().Add(replayNonceTTL)
+
+	sensitiveRequestNonceStore.mu.Lock()
+	defer sensitiveRequestNonceStore.mu.Unlock()
+	sensitiveRequestNonceStore.cleanupExpiredLocked(time.Now())
+	sensitiveRequestNonceStore.records[nonce] = replayNonceRecord{
+		Subject:   subject,
+		Method:    normalizedMethod,
+		Path:      normalizedPath,
+		ExpiresAt: expiresAt,
+	}
+	return nonce, replayNonceTTL, nil
+}
+
+func ValidateAndConsumeReplayNonce(r *http.Request) error {
+	if r == nil {
+		return fmt.Errorf("request can not be nil")
+	}
+
+	nonce := strings.TrimSpace(r.Header.Get(replayNonceHeader))
+	if nonce == "" {
+		return fmt.Errorf("missing replay nonce")
+	}
+
+	subject := replayRequestSubject(r)
+	method, requestPath, err := normalizeReplayScope(r.Method, r.URL.Path)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	sensitiveRequestNonceStore.mu.Lock()
+	defer sensitiveRequestNonceStore.mu.Unlock()
+	sensitiveRequestNonceStore.cleanupExpiredLocked(now)
+
+	record, ok := sensitiveRequestNonceStore.records[nonce]
+	if !ok {
+		return fmt.Errorf("replay nonce is invalid or expired")
+	}
+	delete(sensitiveRequestNonceStore.records, nonce)
+
+	if record.Subject != subject || record.Method != method || record.Path != requestPath {
+		return fmt.Errorf("replay nonce does not match request context")
+	}
+
+	return nil
+}
+
+func (store *replayNonceStore) cleanupExpiredLocked(now time.Time) {
+	for nonce, record := range store.records {
+		if now.After(record.ExpiresAt) {
+			delete(store.records, nonce)
+		}
+	}
+}
+
+func normalizeReplayScope(method, requestPath string) (string, string, error) {
+	normalizedMethod := strings.ToUpper(strings.TrimSpace(method))
+	switch normalizedMethod {
+	case http.MethodPost, http.MethodPut, http.MethodDelete:
+	default:
+		return "", "", fmt.Errorf("unsupported replay-protected method [%s]", method)
+	}
+
+	normalizedPath := strings.TrimSpace(requestPath)
+	if normalizedPath == "" {
+		return "", "", fmt.Errorf("request path can not be empty")
+	}
+	if !strings.HasPrefix(normalizedPath, "/") {
+		normalizedPath = "/" + normalizedPath
+	}
+	normalizedPath = pathutil.Clean(normalizedPath)
+	if normalizedPath == "." {
+		normalizedPath = "/"
+	}
+
+	return normalizedMethod, normalizedPath, nil
+}
+
+func replayRequestSubject(r *http.Request) string {
+	if r == nil {
+		return "anonymous"
+	}
+
+	authorizationHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authorizationHeader == "" {
+		return "anonymous"
+	}
+
+	sum := sha256.Sum256([]byte(authorizationHeader))
+	return hex.EncodeToString(sum[:])
+}

--- a/core/replay_test.go
+++ b/core/replay_test.go
@@ -1,0 +1,79 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReplayNonceCanOnlyBeUsedOnce(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://console.local/account/login", nil)
+
+	nonce, _, err := IssueReplayNonce(req, http.MethodPost, "/account/login")
+	if err != nil {
+		t.Fatalf("issue replay nonce failed: %v", err)
+	}
+
+	req.Header.Set(replayNonceHeader, nonce)
+	if err := ValidateAndConsumeReplayNonce(req); err != nil {
+		t.Fatalf("expected first nonce use to succeed: %v", err)
+	}
+	if err := ValidateAndConsumeReplayNonce(req); err == nil {
+		t.Fatal("expected second nonce use to be rejected")
+	}
+}
+
+func TestReplayNonceBindsToAuthorizationHeader(t *testing.T) {
+	issueReq := httptest.NewRequest(http.MethodPut, "https://console.local/credential/test", nil)
+	issueReq.Header.Set("Authorization", "Bearer token-a")
+
+	nonce, _, err := IssueReplayNonce(issueReq, http.MethodPut, "/credential/test")
+	if err != nil {
+		t.Fatalf("issue replay nonce failed: %v", err)
+	}
+
+	useReq := httptest.NewRequest(http.MethodPut, "https://console.local/credential/test", nil)
+	useReq.Header.Set(replayNonceHeader, nonce)
+	useReq.Header.Set("Authorization", "Bearer token-b")
+	if err := ValidateAndConsumeReplayNonce(useReq); err == nil {
+		t.Fatal("expected nonce bound to a different authorization header to fail")
+	}
+}
+
+func TestReplayNonceBindsToPathAndMethod(t *testing.T) {
+	issueReq := httptest.NewRequest(http.MethodPost, "https://console.local/setup/_initialize", nil)
+
+	nonce, _, err := IssueReplayNonce(issueReq, http.MethodPost, "/setup/_initialize")
+	if err != nil {
+		t.Fatalf("issue replay nonce failed: %v", err)
+	}
+
+	useReq := httptest.NewRequest(http.MethodPut, "https://console.local/setup/_initialize", nil)
+	useReq.Header.Set(replayNonceHeader, nonce)
+	if err := ValidateAndConsumeReplayNonce(useReq); err == nil {
+		t.Fatal("expected nonce with mismatched method to fail")
+	}
+}

--- a/modules/security/api/init.go
+++ b/modules/security/api/init.go
@@ -54,18 +54,19 @@ func Init() {
 	api.HandleAPIMethod(api.PUT, "/role/:id", apiHandler.RequirePermission(apiHandler.UpdateRole, enum.RoleAllPermission...))
 	api.HandleAPIMethod(api.GET, "/role/_search", apiHandler.RequirePermission(apiHandler.SearchRole, enum.RoleReadPermission...))
 
-	api.HandleAPIMethod(api.POST, "/user", apiHandler.RequirePermission(apiHandler.CreateUser, enum.UserAllPermission...))
+	api.HandleAPIMethod(api.POST, "/user", apiHandler.RequireSecureTransport(apiHandler.RequireReplayProtection(apiHandler.RequirePermission(apiHandler.CreateUser, enum.UserAllPermission...))))
 	api.HandleAPIMethod(api.GET, "/user/:id", apiHandler.RequirePermission(apiHandler.GetUser, enum.UserReadPermission...))
 	api.HandleAPIMethod(api.DELETE, "/user/:id", apiHandler.RequirePermission(apiHandler.DeleteUser, enum.UserAllPermission...))
 	api.HandleAPIMethod(api.PUT, "/user/:id", apiHandler.RequirePermission(apiHandler.UpdateUser, enum.UserAllPermission...))
 	api.HandleAPIMethod(api.GET, "/user/_search", apiHandler.RequirePermission(apiHandler.SearchUser, enum.UserReadPermission...))
-	api.HandleAPIMethod(api.PUT, "/user/:id/password", apiHandler.RequirePermission(apiHandler.UpdateUserPassword, enum.UserAllPermission...))
+	api.HandleAPIMethod(api.PUT, "/user/:id/password", apiHandler.RequireSecureTransport(apiHandler.RequireReplayProtection(apiHandler.RequirePermission(apiHandler.UpdateUserPassword, enum.UserAllPermission...))))
 
-	api.HandleAPIMethod(api.POST, "/account/login", apiHandler.Login)
+	api.HandleAPIMethod(api.POST, "/account/replay_nonce", apiHandler.RequireSecureTransport(apiHandler.IssueReplayNonce))
+	api.HandleAPIMethod(api.POST, "/account/login", apiHandler.RequireSecureTransport(apiHandler.RequireReplayProtection(apiHandler.Login)))
 	api.HandleAPIMethod(api.POST, "/account/logout", apiHandler.Logout)
 	api.HandleAPIMethod(api.DELETE, "/account/logout", apiHandler.Logout)
 
 	api.HandleAPIMethod(api.GET, "/account/profile", apiHandler.RequireLogin(apiHandler.Profile))
-	api.HandleAPIMethod(api.PUT, "/account/password", apiHandler.RequireLogin(apiHandler.UpdatePassword))
+	api.HandleAPIMethod(api.PUT, "/account/password", apiHandler.RequireSecureTransport(apiHandler.RequireReplayProtection(apiHandler.RequireLogin(apiHandler.UpdatePassword))))
 
 }

--- a/modules/security/api/replay.go
+++ b/modules/security/api/replay.go
@@ -1,0 +1,55 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	core2 "infini.sh/console/core"
+	httprouter "infini.sh/framework/core/api/router"
+	"net/http"
+	"time"
+)
+
+func (h APIHandler) IssueReplayNonce(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	var req struct {
+		Method string `json:"method"`
+		Path   string `json:"path"`
+	}
+
+	if err := h.DecodeJSON(r, &req); err != nil {
+		h.WriteError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	nonce, ttl, err := core2.IssueReplayNonce(r, req.Method, req.Path)
+	if err != nil {
+		h.WriteError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	h.WriteOKJSON(w, map[string]interface{}{
+		"status":            "ok",
+		"nonce":             nonce,
+		"expire_in_seconds": int(ttl / time.Second),
+	})
+}

--- a/web/src/utils/request.js
+++ b/web/src/utils/request.js
@@ -31,6 +31,149 @@ export const formatResponse = (response) => {
   }
 }
 
+const secureTransportErrorReason =
+  "Sensitive requests require HTTPS. Enable Console HTTPS or put Console behind an HTTPS reverse proxy.";
+const ERROR_NOTIFICATION_DEDUPE_MS = 4000;
+const recentErrorNotifications = new Map();
+
+const sensitiveRequestRules = [
+  { method: "POST", pattern: /^\/account\/login\/challenge$/ },
+  { method: "POST", pattern: /^\/account\/login$/ },
+  { method: "PUT", pattern: /^\/account\/password$/ },
+  { method: "POST", pattern: /^\/user$/ },
+  { method: "PUT", pattern: /^\/user\/[^/]+\/password$/ },
+  { method: "POST", pattern: /^\/credential$/ },
+  { method: "PUT", pattern: /^\/credential\/[^/]+$/ },
+  { method: "POST", pattern: /^\/setup\/_validate$/ },
+  { method: "POST", pattern: /^\/setup\/_initialize$/ },
+  { method: "POST", pattern: /^\/setup\/_validate_secret$/ },
+  { method: "POST", pattern: /^\/elasticsearch\/$/ },
+  { method: "PUT", pattern: /^\/elasticsearch\/[^/]+$/ },
+  { method: "POST", pattern: /^\/elasticsearch\/try_connect$/ },
+  { method: "POST", pattern: /^\/email\/server$/ },
+  { method: "POST", pattern: /^\/email\/server\/_test$/ },
+  { method: "PUT", pattern: /^\/email\/server\/[^/]+$/ },
+  { method: "PUT", pattern: /^\/setting\/system\/rollup$/ },
+  { method: "PUT", pattern: /^\/setting\/system\/retention$/ },
+];
+
+const getNormalizedRequestPath = (requestUrl) => {
+  if (typeof window === "undefined") {
+    return requestUrl;
+  }
+
+  const resolvedUrl = new URL(requestUrl, window.location.origin);
+  let pathname = resolvedUrl.pathname;
+  const basePath =
+    window.routerBase && window.routerBase !== "/"
+      ? window.routerBase.replace(/\/$/, "")
+      : "";
+
+  if (basePath && pathname.startsWith(`${basePath}/`)) {
+    pathname = pathname.slice(basePath.length);
+  } else if (basePath && pathname === basePath) {
+    pathname = "/";
+  }
+
+  return pathname;
+};
+
+const requestUsesSecureTransport = (requestUrl) => {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  return new URL(requestUrl, window.location.origin).protocol === "https:";
+};
+
+const requestRequiresSecureTransport = (requestUrl, method = "GET") => {
+  const normalizedMethod = method.toUpperCase();
+  const normalizedPath = getNormalizedRequestPath(requestUrl);
+
+  return sensitiveRequestRules.some(
+    ({ method: sensitiveMethod, pattern }) =>
+      sensitiveMethod === normalizedMethod && pattern.test(normalizedPath)
+  );
+};
+
+const getInsecureTransportResponse = () => ({
+  status: "error",
+  success: false,
+  currentAuthority: "guest",
+  error: {
+    reason: secureTransportErrorReason,
+  },
+});
+
+const cleanupRecentErrorNotifications = (now = Date.now()) => {
+  recentErrorNotifications.forEach((timestamp, key) => {
+    if (now - timestamp >= ERROR_NOTIFICATION_DEDUPE_MS) {
+      recentErrorNotifications.delete(key);
+    }
+  });
+};
+
+const showErrorNotification = ({
+  message,
+  description,
+  style,
+  dedupeKey,
+}) => {
+  const now = Date.now();
+  cleanupRecentErrorNotifications(now);
+  const key = dedupeKey || `${message}`;
+  const lastShownAt = recentErrorNotifications.get(key);
+  if (lastShownAt && now - lastShownAt < ERROR_NOTIFICATION_DEDUPE_MS) {
+    return;
+  }
+  recentErrorNotifications.set(key, now);
+  notification.error({
+    key,
+    placement: "topRight",
+    message,
+    description,
+    style,
+  });
+};
+
+const fetchReplayNonce = async (requestUrl, requestMethod, authorizationHeader) => {
+  const nonceEndpoint = buildUrlWithBasePath("/account/replay_nonce");
+  const headers = {
+    Accept: "application/json",
+    "Content-Type": "application/json; charset=utf-8",
+  };
+  if (authorizationHeader) {
+    headers.Authorization = authorizationHeader;
+  }
+
+  const response = await fetch(nonceEndpoint, {
+    method: "POST",
+    credentials: "include",
+    headers,
+    body: JSON.stringify({
+      method: requestMethod,
+      path: getNormalizedRequestPath(requestUrl),
+    }),
+  });
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    payload = null;
+  }
+
+  if (!response.ok || !payload?.nonce) {
+    const reason =
+      payload?.error?.reason ||
+      payload?.message ||
+      "failed to fetch replay nonce";
+    throw new Error(reason);
+  }
+
+  return payload.nonce;
+};
+
 const checkStatus = async (response, noticeable, option={}) => {
   const codeMessage = {
     200: formatMessage({ id: "app.message.http.status.200" }),
@@ -54,24 +197,18 @@ const checkStatus = async (response, noticeable, option={}) => {
     return response;
   }
   if (response.status == 500) {
-    const jsonRes = await response.clone().json();
-    if (jsonRes.error && !jsonRes.stack) {
+    let jsonRes = null;
+    try {
+      jsonRes = await response.clone().json();
+    } catch (error) {
+      jsonRes = null;
+    }
+    if (jsonRes?.error && !jsonRes.stack) {
       if (noticeable) {
-        let desc = "";
-        if (typeof jsonRes.error == "string") {
-          desc = jsonRes.error;
-        } else {
-          if (jsonRes.error?.reason) {
-            desc = (
-              <div style={{ color: "rgba(153,153,153,1)" }}>
-                {jsonRes.error.reason}
-              </div>
-            );
-          } else {
-            desc = JSON.stringify(jsonRes.error);
-          }
-        }
-        desc = (
+        const friendlyMessage = jsonRes.error?.key
+          ? formatMessage({ id: jsonRes.error.key })
+          : formatMessage({ id: "app.message.http.status.500" });
+        const desc = (
           <div>
             <div>
               <span
@@ -85,13 +222,16 @@ const checkStatus = async (response, noticeable, option={}) => {
                 {response.status}
               </span>
             </div>
-            {desc}
+            <div style={{ color: "rgba(153,153,153,1)" }}>
+              {friendlyMessage}
+            </div>
           </div>
         );
-        notification.error({
+        showErrorNotification({
           message: formatMessage({ id: "app.message.http.request.error" }),
           description: desc,
           style: { wordBreak: "break-all" },
+          dedupeKey: `http-500:${jsonRes.error?.key || jsonRes.error?.reason || friendlyMessage}`,
         });
       }
       return response;
@@ -104,10 +244,11 @@ const checkStatus = async (response, noticeable, option={}) => {
     option.hasOwnProperty("showErrorInner") &&
     option.showErrorInner === true
   ) {
-    notification.error({
+    showErrorNotification({
       message: response.statusText,
       description: errortext,
       style: { wordBreak: "break-all" },
+      dedupeKey: `http-inner:${response.status}:${response.statusText}:${errortext}`,
     });
     return response;
   }
@@ -136,10 +277,11 @@ const checkStatus = async (response, noticeable, option={}) => {
           {errortext}
         </div>
       );
-      notification.error({
+      showErrorNotification({
         message: `${formatMessage({ id: "app.message.http.request.error" })}`,
         description: desc,
         style: { wordBreak: "break-all" },
+        dedupeKey: `http-status:${response.status}:${errortext}`,
       });
     }
   }
@@ -264,10 +406,11 @@ export default function request(
     signal,
   };
   const newOptions = { ...defaultOptions, ...options };
+  const requestMethod = (newOptions.method || "GET").toUpperCase();
   if (
-    newOptions.method === "POST" ||
-    newOptions.method === "PUT" ||
-    newOptions.method === "DELETE"
+    requestMethod === "POST" ||
+    requestMethod === "PUT" ||
+    requestMethod === "DELETE"
   ) {
     if (!(newOptions.body instanceof FormData)) {
       newOptions.headers = {
@@ -295,6 +438,19 @@ export default function request(
     newOptions.headers["Authorization"] = authorizationHeader;
   }
 
+  const requiresSecureTransport = requestRequiresSecureTransport(url, requestMethod);
+  if (requiresSecureTransport && !requestUsesSecureTransport(url)) {
+    if (noticeable) {
+      showErrorNotification({
+        message: "HTTPS required",
+        description: secureTransportErrorReason,
+        style: { wordBreak: "break-all" },
+        dedupeKey: `https-required:${getNormalizedRequestPath(url)}`,
+      });
+    }
+    return Promise.resolve(getInsecureTransportResponse());
+  }
+
   const expirys = options.expirys && 60;
   // options.expirys !== false, return the cache,
   if (options.expirys !== false) {
@@ -311,8 +467,11 @@ export default function request(
     }
   }
 
-  return (
-    fetch(url, newOptions)
+  const sendRequest = (nonce) => {
+    if (nonce) {
+      newOptions.headers["X-Request-Nonce"] = nonce;
+    }
+    return fetch(url, newOptions)
       .then((res) => checkStatus(res, noticeable, option))
       // .then(response => cachedSave(response, hashcode))
       .then((response) => {
@@ -332,11 +491,15 @@ export default function request(
           //connection refused
           const err = new Error();
           err.name = "ERR_CONNECTION_REFUSED";
-          err.message = "Failed to connnect server";
+          err.message = formatMessage({
+            id: "error.request.connection_refused",
+          });
           if (typeof setGlobalHealth === "function") {
             setGlobalHealth({
               error: err.name,
-              desc: err.message,
+              desc: formatMessage({
+                id: "error.request.connection_refused.tip",
+              }),
             });
           }
           return err;
@@ -344,7 +507,7 @@ export default function request(
 
         if (status === "AbortError") {
           if (noticeable) {
-            notification.error({
+            showErrorNotification({
               message: formatMessage({
                 id: "app.message.http.request.timeout",
               }),
@@ -355,6 +518,7 @@ export default function request(
                 "\r\nURL:" +
                 url,
               style: { wordBreak: "break-all" },
+              dedupeKey: `request-timeout:${url}`,
             });
           }
           return;
@@ -364,9 +528,15 @@ export default function request(
           if (status === 401) {
             // @HACK
             /* eslint-disable no-underscore-dangle */
-            if (location.href.indexOf("user/login") === -1) {
+            if (
+              option?.skipAuthRedirect !== true &&
+              location.href.indexOf("user/login") === -1
+            ) {
               window.g_app._store.dispatch({
                 type: "login/logout",
+                payload: {
+                  skipServerLogout: true,
+                },
               });
             }
           }
@@ -392,6 +562,24 @@ export default function request(
           return e.rawResponse;
         }
         return e.response;
-      })
-  );
+      });
+  };
+
+  const noncePromise = requiresSecureTransport
+    ? fetchReplayNonce(url, requestMethod, authorizationHeader)
+    : Promise.resolve(null);
+
+  const handleNonceError = (error) => {
+    if (noticeable) {
+      showErrorNotification({
+        message: "Request rejected",
+        description: error?.message || "failed to fetch replay nonce",
+        style: { wordBreak: "break-all" },
+        dedupeKey: `request-rejected:${getNormalizedRequestPath(url)}:${error?.message || "failed to fetch replay nonce"}`,
+      });
+    }
+    return getInsecureTransportResponse();
+  };
+
+  return noncePromise.then((nonce) => sendRequest(nonce), handleNonceError);
 }


### PR DESCRIPTION
## Summary
- add core helpers for HTTPS detection and one-time replay nonces
- protect sensitive account and user endpoints with secure transport and replay checks
- teach the frontend request layer to block insecure sensitive requests and attach replay nonces

## Testing
- go test ./core ./modules/security/api
- NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' ./node_modules/.bin/umi build