### PR TITLE
improve: refresh cluster and platform overviews

### DIFF
--- a/modules/elastic/api/cluster_overview.go
+++ b/modules/elastic/api/cluster_overview.go
@@ -1326,7 +1326,7 @@ func (h *APIHandler) SearchClusterMetadata(w http.ResponseWriter, req *http.Requ
 		}
 	}
 
-	clusterFilter, hasAllPrivilege := h.GetClusterFilter(req, "_id")
+	clusterFilter, hasAllPrivilege := h.GetClusterFilter(req, "id")
 	if !hasAllPrivilege && clusterFilter == nil {
 		h.WriteJSON(w, elastic.SearchResponse{}, http.StatusOK)
 		return

--- a/modules/elastic/api/v1/cluster_overview.go
+++ b/modules/elastic/api/v1/cluster_overview.go
@@ -973,7 +973,7 @@ func (h *APIHandler) SearchClusterMetadata(w http.ResponseWriter, req *http.Requ
 		}
 	}
 
-	clusterFilter, hasAllPrivilege := h.GetClusterFilter(req, "_id")
+	clusterFilter, hasAllPrivilege := h.GetClusterFilter(req, "id")
 	if !hasAllPrivilege && clusterFilter == nil {
 		h.WriteJSON(w, elastic.SearchResponse{}, http.StatusOK)
 		return

--- a/modules/elastic/api/v1/manage.go
+++ b/modules/elastic/api/v1/manage.go
@@ -292,7 +292,7 @@ func (h *APIHandler) HandleSearchClusterAction(w http.ResponseWriter, req *http.
 		name        = h.GetParameterOrDefault(req, "name", "")
 		sortField   = h.GetParameterOrDefault(req, "sort_field", "")
 		sortOrder   = h.GetParameterOrDefault(req, "sort_order", "")
-		queryDSL    = `{"query":{"bool":{"must":[%s]}}, "size": %d, "from": %d%s}`
+		queryDSL    = `{"query":{"bool":{"must":[%s]}}, "size": %d, "from": %d%s%s}`
 		strSize     = h.GetParameterOrDefault(req, "size", "20")
 		strFrom     = h.GetParameterOrDefault(req, "from", "0")
 		mustBuilder = &strings.Builder{}
@@ -300,7 +300,7 @@ func (h *APIHandler) HandleSearchClusterAction(w http.ResponseWriter, req *http.
 	if name != "" {
 		mustBuilder.WriteString(fmt.Sprintf(`{"prefix":{"name.text": "%s"}}`, name))
 	}
-	clusterFilter, hasAllPrivilege := h.GetClusterFilter(req, "_id")
+	clusterFilter, hasAllPrivilege := h.GetClusterFilter(req, "id")
 	if !hasAllPrivilege && clusterFilter == nil {
 		h.WriteJSON(w, elastic.SearchResponse{}, http.StatusOK)
 		return
@@ -311,6 +311,9 @@ func (h *APIHandler) HandleSearchClusterAction(w http.ResponseWriter, req *http.
 		}
 		mustBuilder.Write(util.MustToJSONBytes(clusterFilter))
 	}
+	if mustBuilder.Len() == 0 {
+		mustBuilder.WriteString(`{"match_all":{}}`)
+	}
 
 	size, _ := strconv.Atoi(strSize)
 	if size <= 0 {
@@ -320,23 +323,38 @@ func (h *APIHandler) HandleSearchClusterAction(w http.ResponseWriter, req *http.
 	if from < 0 {
 		from = 0
 	}
-	var sort = ""
+	var (
+		functions  = ""
+		sort       = ""
+		trackScore = ""
+	)
 	if sortField != "" && sortOrder != "" {
 		sort = fmt.Sprintf(`,"sort":[{"%s":{"order":"%s"}}]`, sortField, sortOrder)
+	} else {
+		functions = `,"functions":[{"filter":{"term":{"labels.health_status":"red"}},"weight":300},{"filter":{"term":{"labels.health_status":"yellow"}},"weight":200},{"filter":{"term":{"labels.health_status":"unavailable"}},"weight":100},{"filter":{"term":{"labels.health_status":"green"}},"weight":1}]`
+		sort = `,"sort":[{"_score":{"order":"desc"}},{"name.keyword":{"order":"asc","unmapped_type":"keyword"}}]`
+		trackScore = `,"track_scores":true`
+		queryDSL = `{"query":{"function_score":{"query":{"bool":{"must":[%s]}}%s,"score_mode":"sum","boost_mode":"replace"}}, "size": %d, "from": %d%s%s}`
 	}
 
-	queryDSL = fmt.Sprintf(queryDSL, mustBuilder.String(), size, from, sort)
+	queryDSL = fmt.Sprintf(queryDSL, mustBuilder.String(), functions, size, from, sort, trackScore)
 	q := orm.Query{
 		RawQuery: []byte(queryDSL),
 	}
 	err, result := orm.Search(elastic.ElasticsearchConfig{}, &q)
 	if err != nil {
+		if global.Env().IsDebug {
+			log.Errorf("cluster search failed, name=%q, from=%d, size=%d, dsl=%s, err=%v", name, from, size, queryDSL, err)
+		}
 		log.Error(err)
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	searchRes := elastic.SearchResponse{}
 	util.MustFromJSONBytes(result.Raw, &searchRes)
+	if global.Env().IsDebug && len(searchRes.Hits.Hits) == 0 {
+		log.Debugf("cluster search returned zero hits, name=%q, from=%d, size=%d, dsl=%s", name, from, size, queryDSL)
+	}
 	if len(searchRes.Hits.Hits) > 0 {
 		for _, hit := range searchRes.Hits.Hits {
 			if basicAuth, ok := hit.Source["basic_auth"]; ok {

--- a/web/src/components/Overview/Detail/Content.tsx
+++ b/web/src/components/Overview/Detail/Content.tsx
@@ -1,4 +1,5 @@
 import { Tabs } from "antd";
+import { formatMessage } from "umi/locale";
 
 interface IProps {
   data: any;
@@ -24,7 +25,10 @@ export default (props: IProps) => {
         tabPosition="right"
       >
         {details.map((pane) => (
-          <Tabs.TabPane tab={pane.title} key={pane.key}>
+          <Tabs.TabPane
+            tab={pane.titleId ? formatMessage({ id: pane.titleId }) : pane.title}
+            key={pane.key}
+          >
             {typeof pane.component == "string" ? (
               pane.component
             ) : (

--- a/web/src/components/Overview/Detail/Metrics/MetricIndices.jsx
+++ b/web/src/components/Overview/Detail/Metrics/MetricIndices.jsx
@@ -99,7 +99,7 @@ export default ({ clusterID, clusterName, timeRange, action }) => {
 
   const columns = [
     {
-      title: "Name",
+      title: formatMessage({ id: "overview.column.name" }),
       dataIndex: "index",
       render: (text, record) => (
         <IconText
@@ -118,7 +118,7 @@ export default ({ clusterID, clusterName, timeRange, action }) => {
       sorter: (a, b) => sorter.string(a, b, "index"),
     },
     {
-      title: "Health",
+      title: formatMessage({ id: "overview.column.health" }),
       dataIndex: "health",
       render: (text, record) => <HealthStatusView status={record?.health} />,
       sorter: (a, b) => sorter.string(a, b, "health"),
@@ -178,14 +178,14 @@ export default ({ clusterID, clusterName, timeRange, action }) => {
       >
         <div style={{ maxWidth: 300, flex: "1 1 auto" }}>
           <Search
-            placeholder="Type keyword to search"
+            placeholder={formatMessage({ id: "listview.search.placeholder" })}
             onSearch={(value) => {
               setSearchValue(value);
             }}
             onChange={(e) => {
               setSearchValue(e.currentTarget.value);
             }}
-            enterButton
+            enterButton={formatMessage({ id: "form.button.search" })}
           />
         </div>
         <Dropdown overlay={menu} placement="bottomRight">

--- a/web/src/components/Overview/Detail/Metrics/MetricNodes.jsx
+++ b/web/src/components/Overview/Detail/Metrics/MetricNodes.jsx
@@ -73,7 +73,7 @@ export default ({ clusterID, clusterName, timeRange, action }) => {
 
   const columns = [
     {
-      title: "Name",
+      title: formatMessage({ id: "overview.column.name" }),
       dataIndex: "name",
       render: (text, record) => (
         <IconText
@@ -100,7 +100,7 @@ export default ({ clusterID, clusterName, timeRange, action }) => {
       sorter: (a, b) => sorter.string(a, b, "name"),
     },
     {
-      title: "Status",
+      title: formatMessage({ id: "overview.column.status" }),
       dataIndex: "status",
       render: (text, record) => <HealthStatusView status={text} />,
       sorter: (a, b) => sorter.string(a, b, "status"),
@@ -119,14 +119,14 @@ export default ({ clusterID, clusterName, timeRange, action }) => {
       >
         <div style={{ maxWidth: 300, flex: "1 1 auto" }}>
           <Search
-            placeholder="Type keyword to search"
+            placeholder={formatMessage({ id: "listview.search.placeholder" })}
             onSearch={(value) => {
               setSearchValue(value);
             }}
             onChange={(e) => {
               setSearchValue(e.currentTarget.value);
             }}
-            enterButton
+            enterButton={formatMessage({ id: "form.button.search" })}
           />
         </div>
         <div>

--- a/web/src/components/Overview/Detail/Metrics/index.js
+++ b/web/src/components/Overview/Detail/Metrics/index.js
@@ -155,7 +155,14 @@ export default (props) => {
         <div className={styles.metricWrapper}>
           <Tabs size={"small"}>
             {overviews.map((item) => (
-              <TabPane tab={item.title} key={item.key}>
+              <TabPane
+                tab={
+                  item.titleId
+                    ? formatMessage({ id: item.titleId })
+                    : item.title
+                }
+                key={item.key}
+              >
                 <item.component
                   timeRange={state.timeRange}
                   action={item.action}

--- a/web/src/components/Overview/Header/index.tsx
+++ b/web/src/components/Overview/Header/index.tsx
@@ -1,6 +1,7 @@
 import { HealthStatusCircle } from "@/components/infini/health_status_circle";
 import request from "@/utils/request";
 import { AutoComplete, Input, Select, Button, Radio, Icon } from "antd";
+import { formatMessage } from "umi/locale";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import Filters from "./Filters";
 import styles from "./index.scss";
@@ -183,7 +184,7 @@ export default (props: IProps) => {
               allowClear={true}
               style={{ width: filterWidth }}
               dropdownMatchSelectWidth={false}
-              placeholder="Filters"
+              placeholder={formatMessage({ id: "listview.filters.placeholder" })}
               onChange={onSearchFieldChange}
               value={searchField}
             >
@@ -218,8 +219,8 @@ export default (props: IProps) => {
               {...autoCompleteProps}
             >
               <Input.Search
-                placeholder="Type keyword to search"
-                enterButton="Search"
+                placeholder={formatMessage({ id: "listview.search.placeholder" })}
+                enterButton={formatMessage({ id: "form.button.search" })}
                 onSearch={(value) => {
                   onSearchChange(value);
                   setSearchOpen(false);

--- a/web/src/components/Overview/Monitor/index.jsx
+++ b/web/src/components/Overview/Monitor/index.jsx
@@ -119,7 +119,15 @@ const Monitor = (props) => {
   const [timeZone, setTimeZone] = useState(() => allTimeSettingsCache.timeZone || getTimezone());
 
   useEffect(() => {
-    setParam({ ...param, timeRange: state.timeRange, timeInterval: state.timeInterval, timeout: state.timeout });
+    const newParam = {
+      ...param,
+      timeRange: state.timeRange,
+      timeInterval: state.timeInterval,
+      timeout: state.timeout
+    };
+    if (JSON.stringify(newParam) !== JSON.stringify(param)) {
+      setParam(newParam);
+    }
   }, [state.timeRange, state.timeInterval, state.timeout]);
 
   const handleTimeChange = ({ start, end, timeInterval, timeout, refresh }) => {
@@ -236,10 +244,10 @@ const Monitor = (props) => {
                       recentlyUsedRangesKey={'monitor'}
                     />
                   </div>
-                  <div style={{display: "flex"}}>
+                  <div className={styles.statusActions}>
                     {isSystemCluster(selectedCluster?.id) && getRollupEnabled() === "true" && <RollupStats
                       fetchUrl={`${ESPrefix}/${selectedCluster?.id}/_proxy?method=GET&path=/_rollup/jobs/*/_explain`}
-                      style={{ marginRight: 100 }}/>}
+                    />}
                     <CollectStatus filter={collectionStatsFilter} fetchUrl={`${ESPrefix}/${selectedCluster?.id}/_collection_stats`}/>
                   </div>
                 </div>

--- a/web/src/components/Overview/Monitor/index.less
+++ b/web/src/components/Overview/Monitor/index.less
@@ -5,3 +5,11 @@
         }
     }
 }
+
+.statusActions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 16px;
+}

--- a/web/src/components/Overview/Side/index.scss
+++ b/web/src/components/Overview/Side/index.scss
@@ -1,6 +1,15 @@
 .search-filter {
-  margin-top: 56px;
-  padding: 0 10px;
+  height: 100%;
+  .search-filter-title {
+    font-weight: bold;
+    margin-bottom: 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .search-filter-reset {
+    cursor: pointer;
+  }
   .facet-cnt {
     display: flex;
     flex-direction: column;

--- a/web/src/components/Overview/Side/index.tsx
+++ b/web/src/components/Overview/Side/index.tsx
@@ -2,6 +2,8 @@ import Sorter from "@/components/infini/search/sort/sort";
 import { getSearchFacets } from "@/lib/elasticsearch/search";
 import request from "@/utils/request";
 import { useEffect, useState } from "react";
+import { Icon } from "antd";
+import { formatMessage } from "umi/locale";
 import SearchFacet from "./SearchFacet";
 import './index.scss';
 
@@ -16,6 +18,7 @@ interface IProps {
     }
     filters: {[key: string]: string};
     onFacetChange: (facet: any) => void;
+    onReset?: () => void;
 }
 
 interface IFacet {
@@ -32,7 +35,8 @@ export default (props: IProps) => {
         facetLabels, 
         aggsConfig : { action, params }, 
         filters, 
-        onFacetChange 
+        onFacetChange,
+        onReset
     } = props;
 
     const [facets, setFacets] = useState<IFacet[]>([]);
@@ -59,7 +63,17 @@ export default (props: IProps) => {
 
     return (
         <div className="search-filter">
-            <div style={{ marginBottom: 10 }}>
+            <div className="search-filter-title">
+                <span>{formatMessage({ id: "listview.side.filter" })}</span>
+                <span
+                    className="search-filter-reset"
+                    onClick={onReset}
+                    title={formatMessage({ id: "listview.side.filter.reset" })}
+                >
+                    <Icon type="reload" style={{ color: "rgba(0, 127, 255, 1)" }} />
+                </span>
+            </div>
+            <div style={{ marginBottom: 16 }}>
                 <Sorter
                     options={sorterOptions}
                     value={sorterValues}

--- a/web/src/components/Overview/index.scss
+++ b/web/src/components/Overview/index.scss
@@ -1,17 +1,49 @@
 .overview-wrapper {
-  .content {
-    display: flex;
-    gap: 1em;
-    margin-top: 10px;
-    .ant-list-item {
-      border-bottom: none !important;
-    }
-    .left {
-      flex: 1 1 auto;
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+
+  .overview-side-wrap {
+    min-height: calc(100vh - 220px);
+    padding: 24px 15px;
+    background-color: #ffffff;
+    flex: 0 0 220px;
+    width: 220px;
+  }
+
+  .overview-content-wrap {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .overview-expand-and-collapse {
+    cursor: pointer;
+    z-index: 10;
+    position: absolute;
+    top: 24px;
+    left: 0;
+    width: 14px;
+    height: 32px;
+    line-height: 32px;
+    border-radius: 0 4px 4px 0;
+    background-color: rgba(234, 244, 255, 1);
+    text-align: center;
+  }
+
+  .overview-content-card {
+    min-height: calc(100vh - 220px);
+    .content {
+      .ant-list-item {
+        border-bottom: none !important;
+      }
       .search-result {
-        min-width: 900px;
+        width: 100%;
+        min-width: 0;
+        overflow-x: auto;
         margin-top: 15px;
         .table-wrap {
+          min-width: 0;
           margin-top: 24px;
           .ant-progress-inner {
             border-radius: 0;
@@ -21,6 +53,12 @@
           }
         }
       }
+    }
+  }
+
+  &.collapse {
+    .overview-side-wrap {
+      display: none;
     }
   }
 }

--- a/web/src/components/Overview/index.tsx
+++ b/web/src/components/Overview/index.tsx
@@ -9,6 +9,8 @@ import React, {
 import useFetch from "@/lib/hooks/use_fetch";
 import "./index.scss";
 import request from "@/utils/request";
+import { Button, Card, Icon } from "antd";
+import { formatMessage } from "umi/locale";
 import { JsonParam, useQueryParam } from "use-query-params";
 import Header from "./Header";
 import List from "./List";
@@ -17,6 +19,7 @@ import Drawer, { IDrawerRef } from "./Drawer";
 import Title from "./Detail/Title";
 import Content from "./Detail/Content";
 import { useLocalStorage } from "@/lib/hooks/storage";
+import isEqual from "lodash/isEqual";
 
 interface IQueryParams {
   from: number;
@@ -27,6 +30,7 @@ interface IQueryParams {
 interface IDetail {
   key: string;
   title: string;
+  titleId?: string;
   component: any;
 }
 
@@ -101,6 +105,7 @@ export default forwardRef((props: IProps, ref: any) => {
   } = props;
 
   const drawRef = useRef<IDrawerRef>(null);
+  const [sideVisible, setSideVisible] = useState(false);
 
   const [searchField, setSearchField] = useState<string>();
   const [selectedItem, setSelectedItem] = useState<IRecord>({});
@@ -177,6 +182,7 @@ export default forwardRef((props: IProps, ref: any) => {
 
   const result = (value as any)?.hits || {};
   const { hits = [] } = result;
+  const hasSide = sideSorterOptions.length > 0 || aggsParams.length > 0;
 
   const initQueryParams = () => {
     extraQueryFields.forEach((item) => {
@@ -204,6 +210,16 @@ export default forwardRef((props: IProps, ref: any) => {
     dispatch({ type: "pagination", value: 1 })
   };
 
+  const onSideReset = () => {
+    const { filters, ...restParams } = param || {};
+    setParam(restParams);
+    dispatch({ type: "pagination", value: 1 });
+  };
+
+  const onRefresh = () => {
+    run();
+  };
+
   useEffect(() => {
     if (hits.length === 0) {
       return;
@@ -213,8 +229,12 @@ export default forwardRef((props: IProps, ref: any) => {
   }, [value]);
 
   useEffect(() => {
-    setParam({ ...param, ...queryParams });
-  }, [JSON.stringify(queryParams)]);
+    const nextParam = { ...(param || {}), ...queryParams };
+    if (isEqual(param || {}, nextParam)) {
+      return;
+    }
+    setParam(nextParam);
+  }, [param, queryParams, setParam]);
 
   useEffect(() => {
     initQueryParams();
@@ -226,106 +246,139 @@ export default forwardRef((props: IProps, ref: any) => {
 
   return (
     <>
-      <div className="overview-wrapper">
-        <div className="content">
-          <div className="left">
-            <Header
-              searchField={searchField}
-              filters={param?.filters || {}}
-              selectFilterLabels={selectFilterLabels || facetLabels}
-              onSearchFieldChange={(value) => {
-                setSearchField(value);
-                setParam({ ...param, search_field: value });
-              }}
-              defaultSearchValue={queryParams?.keyword}
-              onSearchChange={(value) => {
-                dispatch({ type: "search", value })
-              }}
-              onFacetChange={onFacetChange}
-              dispalyType={dispalyTypeObj[currentTab]}
-              onDisplayTypeChange={onDisplayTypeChange}
-              autoCompleteConfig={{
-                action: searchAction,
-                highlightFields: searchHighlightFields,
-                ...searchAutoCompleteConfig,
-              }}
-              {...headerConfig}
-              onCleanSuccess={() => {
-                dispatch({ type: "pagination", value: 1 })
-              }}
-            />
-            <div className="search-result">
-              {dispalyTypeObj[currentTab] == "card" ? (
-                <List
-                  dataSource={hits}
-                  total={result?.total?.value || 0}
-                  from={queryParams.from}
-                  pageSize={queryParams.size}
-                  loading={loading}
-                  onPageChange={(page) =>
-                    dispatch({ type: "pagination", value: page })
-                  }
-                  onPageSizeChange={(size) =>
-                    dispatch({ type: "pageSizeChange", value: size })
-                  }
-                  renderItem={(item) => {
-                    const infoField = listItemConfig.getId(item);
-                    return (
-                      <listItemConfig.component
-                        data={item}
-                        id={infoField}
-                        isActive={listItemConfig.getId(selectedItem?._id) == infoField}
-                        onSelect={() => {
-                          setSelectedItem(item);
-                          drawRef.current?.open();
-                        }}
-                        onChangeFacet={onFacetChange}
-                        infoAction={infoAction}
-                        parentLoading={loading}
-                      />
-                    );
-                  }}
-                />
-              ) : (
-                <tableConfig.component
-                  infoAction={infoAction}
-                  dataSource={hits.map((item) => ({...item, id: listItemConfig.getId(item)}))}
-                  total={result?.total?.value || 0}
-                  from={queryParams.from}
-                  pageSize={queryParams.size}
-                  loading={loading}
-                  onPageChange={(page) =>
-                    dispatch({ type: "pagination", value: page })
-                  }
-                  onPageSizeChange={(size) =>
-                    dispatch({ type: "pageSizeChange", value: size })
-                  }
-                  onRowClick={(item) => {
-                    setSelectedItem(item);
-                    drawRef.current?.open();
-                  }}
-                  parentLoading={loading}
-                />
-              )}
-            </div>
+      <div className={`overview-wrapper ${hasSide && sideVisible ? "expand" : "collapse"}`}>
+        {hasSide ? (
+          <div className="overview-side-wrap">
+            {sideVisible ? (
+              <Side
+                sorterOptions={sideSorterOptions}
+                sorterValues={param?.sort || []}
+                onSorterChange={(sort) => {
+                  setParam({
+                    ...param,
+                    sort,
+                  });
+                }}
+                facetLabels={facetLabels}
+                aggsConfig={{
+                  action: searchAction,
+                  params: aggsParams,
+                }}
+                filters={param?.filters || {}}
+                onFacetChange={onFacetChange}
+                onReset={onSideReset}
+              />
+            ) : null}
           </div>
-          <Side
-            sorterOptions={sideSorterOptions}
-            sorterValues={param?.sort || []}
-            onSorterChange={(sort) => {
-              setParam({
-                ...param,
-                sort,
-              });
-            }}
-            facetLabels={facetLabels}
-            aggsConfig={{
-              action: searchAction,
-              params: aggsParams,
-            }}
-            filters={param?.filters || {}}
-            onFacetChange={onFacetChange}
-          />
+        ) : null}
+        <div className="overview-content-wrap">
+          {hasSide ? (
+            <span
+              className="overview-expand-and-collapse"
+              onClick={() => setSideVisible((visible) => !visible)}
+              title={
+                sideVisible
+                  ? formatMessage({ id: "listview.side.button.collapse" })
+                  : formatMessage({ id: "listview.side.button.expand" })
+              }
+            >
+              <Icon type={sideVisible ? "left" : "right"} style={{ fontSize: 12 }} />
+            </span>
+          ) : null}
+          <Card className="overview-content-card">
+            <div className="content">
+              <Header
+                searchField={searchField}
+                filters={param?.filters || {}}
+                selectFilterLabels={selectFilterLabels || facetLabels}
+                onSearchFieldChange={(value) => {
+                  setSearchField(value);
+                  setParam({ ...param, search_field: value });
+                }}
+                defaultSearchValue={queryParams?.keyword}
+                onSearchChange={(value) => {
+                  dispatch({ type: "search", value })
+                }}
+                onFacetChange={onFacetChange}
+                dispalyType={dispalyTypeObj[currentTab]}
+                onDisplayTypeChange={onDisplayTypeChange}
+                autoCompleteConfig={{
+                  action: searchAction,
+                  highlightFields: searchHighlightFields,
+                  ...searchAutoCompleteConfig,
+                }}
+                {...headerConfig}
+                getExtra={(headerProps) => {
+                  const extras = headerConfig.getExtra
+                    ? headerConfig.getExtra(headerProps)
+                    : [];
+                  return [
+                    <Button key="refresh" icon="redo" onClick={onRefresh}>
+                      {formatMessage({ id: "form.button.refresh" })}
+                    </Button>,
+                    ...extras,
+                  ];
+                }}
+                onCleanSuccess={() => {
+                  dispatch({ type: "pagination", value: 1 })
+                }}
+              />
+              <div className="search-result">
+                {dispalyTypeObj[currentTab] == "card" ? (
+                  <List
+                    dataSource={hits}
+                    total={result?.total?.value || 0}
+                    from={queryParams.from}
+                    pageSize={queryParams.size}
+                    loading={loading}
+                    onPageChange={(page) =>
+                      dispatch({ type: "pagination", value: page })
+                    }
+                    onPageSizeChange={(size) =>
+                      dispatch({ type: "pageSizeChange", value: size })
+                    }
+                    renderItem={(item) => {
+                      const infoField = listItemConfig.getId(item);
+                      return (
+                        <listItemConfig.component
+                          data={item}
+                          id={infoField}
+                          isActive={listItemConfig.getId(selectedItem?._id) == infoField}
+                          onSelect={() => {
+                            setSelectedItem(item);
+                            drawRef.current?.open();
+                          }}
+                          onChangeFacet={onFacetChange}
+                          infoAction={infoAction}
+                          parentLoading={loading}
+                        />
+                      );
+                    }}
+                  />
+                ) : (
+                  <tableConfig.component
+                    infoAction={infoAction}
+                    dataSource={hits.map((item) => ({...item, id: listItemConfig.getId(item)}))}
+                    total={result?.total?.value || 0}
+                    from={queryParams.from}
+                    pageSize={queryParams.size}
+                    loading={loading}
+                    onPageChange={(page) =>
+                      dispatch({ type: "pagination", value: page })
+                    }
+                    onPageSizeChange={(size) =>
+                      dispatch({ type: "pageSizeChange", value: size })
+                    }
+                    onRowClick={(item) => {
+                      setSelectedItem(item);
+                      drawRef.current?.open();
+                    }}
+                    parentLoading={loading}
+                  />
+                )}
+              </div>
+            </div>
+          </Card>
         </div>
       </div>
       <Drawer

--- a/web/src/pages/Cluster/NewOverview.js
+++ b/web/src/pages/Cluster/NewOverview.js
@@ -17,10 +17,14 @@ import { default as Hosts } from "./components/host/host_table";
 const { TabPane } = Tabs;
 
 const panes = [
-  { title: "Clusters", component: Clusters, key: "clusters" },
-  { title: "Nodes", component: Nodes, key: "nodes" },
-  { title: "Indices", component: Indices, key: "indices" },
-  // { title: "Hosts", component: Hosts, key: "hosts" },
+  {
+    titleId: "overview.title.cluster",
+    component: Clusters,
+    key: "clusters",
+  },
+  { titleId: "overview.title.node", component: Nodes, key: "nodes" },
+  { titleId: "overview.title.index", component: Indices, key: "indices" },
+  // { titleId: "overview.title.host", component: Hosts, key: "hosts" },
 ];
 
 const NewOverview = (props) => {
@@ -128,7 +132,12 @@ const NewOverview = (props) => {
           activeKey={param?.tab || "clusters"}
         >
           {panes.map((pane) => (
-            <TabPane tab={pane.title} key={pane.key}>
+            <TabPane
+              tab={formatMessage({
+                id: pane.titleId,
+              })}
+              key={pane.key}
+            >
               {typeof pane.component == "string" ? (
                 pane.component
               ) : (

--- a/web/src/pages/Cluster/Settings/Repository.js
+++ b/web/src/pages/Cluster/Settings/Repository.js
@@ -24,7 +24,7 @@ class Repository extends Component {
     {
       title: '仓库名',
       dataIndex: 'id',
-      render: (text, record) => (<Fragment>
+      render: (text, record) => (<Fragment key={record.id}>
           <a onClick={() => this.handleRepoClick(record)}>{record.id}</a>
         </Fragment>
       )
@@ -36,7 +36,7 @@ class Repository extends Component {
     {
       title: '操作',
       render: (text, record) => (
-        <Fragment>
+        <Fragment key={record.id}>
           {/* <a onClick={() => this.handleDownload(record)}>下载</a>
           <Divider type="vertical" /> */}
           <a onClick={() => {
@@ -82,7 +82,7 @@ class Repository extends Component {
 
   render() {
     return (
-      <Fragment>
+      <Fragment key="repository">
         <Card
           bordered={false}
           onTabChange={this.onOperationTabChange}

--- a/web/src/pages/Cluster/components/clusters.js
+++ b/web/src/pages/Cluster/components/clusters.js
@@ -31,7 +31,7 @@ import { JsonParam, useQueryParam } from "use-query-params";
 import { HealthStatusCircle } from "@/components/infini/health_status_circle";
 import Sorter from "@/components/infini/search/sort/sort";
 
-const { Search } = Input;
+import SearchInput from "@/components/infini/SearchInput";
 const InputGroup = Input.Group;
 const Option = Select.Option;
 const filterWidth = 120;
@@ -295,7 +295,7 @@ const Clusters = (props) => {
                   open={searchOpen}
                   onDropdownVisibleChange={setSearchOpen}
                 >
-                  <Search
+                  <SearchInput
                     placeholder="Type keyword to search"
                     enterButton="Search"
                     onSearch={(value) => {

--- a/web/src/pages/Cluster/components/detail/metric_topn.jsx
+++ b/web/src/pages/Cluster/components/detail/metric_topn.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { ESPrefix } from "@/services/common";
 import useFetch from "@/lib/hooks/use_fetch";
 import Treemap from "@/components/infini/charts/Treemap";
+import { getLocalizedTreemapTitle } from "@/utils/treemap_title";
 
 export const MetricTopN = (props) => {
   const clusterID = props.data?._id || null;
@@ -18,7 +19,7 @@ export const MetricTopN = (props) => {
   return (
     <div>
       <div style={{ marginTop: "10px", marginBottom: "10px" }}>
-        <div>{treemapResult?._source?.name}</div>
+        <div>{getLocalizedTreemapTitle(treemapResult?._source?.name)}</div>
         {treemapData.children ? (
           <Treemap
             data={treemapData}

--- a/web/src/pages/Cluster/components/host/detail/metrics.js
+++ b/web/src/pages/Cluster/components/host/detail/metrics.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { ESPrefix } from "@/services/common";
 import useFetch from "@/lib/hooks/use_fetch";
 import Treemap from "@/components/infini/charts/Treemap";
+import { getLocalizedTreemapTitle } from "@/utils/treemap_title";
 
 export const Metrics = (props)=>{
   const id = props.data?._id || null;
@@ -21,7 +22,7 @@ export const Metrics = (props)=>{
   return (
     <div>
       <div style={{marginTop:"10px",marginBottom:"10px"}}>
-      <div>{treemapResult?._source?.name}</div>
+      <div>{getLocalizedTreemapTitle(treemapResult?._source?.name)}</div>
         <Treemap data={treemapData} colorField={"name"} drilldownEnabled={true}/>
       </div>
     </div>

--- a/web/src/pages/Cluster/components/host/hosts.jsx
+++ b/web/src/pages/Cluster/components/host/hosts.jsx
@@ -8,7 +8,7 @@ import HostDetail from "./host_detail";
 import { TagList } from "../tag";
 import HostCard from "./host_card";
 
-const { Search } = Input;
+import SearchInput from "@/components/infini/SearchInput";
 
 const Hosts = (props) => {
   const [collapse, setCollapse] = React.useState(false);
@@ -64,7 +64,7 @@ const Hosts = (props) => {
         <div className={"col left" + (collapse ? " collapse" : "")}>
           <div className="search-line">
             <div className="search-box">
-              <Search
+              <SearchInput
                 placeholder="search"
                 enterButton="Search"
                 onSearch={(value) => dispatch({ type: "search", value: value })}

--- a/web/src/pages/Cluster/components/index/indices.jsx
+++ b/web/src/pages/Cluster/components/index/indices.jsx
@@ -32,7 +32,7 @@ import SearchSelectFacet from "../search_select_facet";
 import { FilteredTags } from "../filtered_tags";
 import Sorter from "@/components/infini/search/sort/sort";
 
-const { Search } = Input;
+import SearchInput from "@/components/infini/SearchInput";
 const InputGroup = Input.Group;
 const Option = Select.Option;
 const filterWidth = 120;
@@ -292,7 +292,7 @@ const Indices = (props) => {
                   open={searchOpen}
                   onDropdownVisibleChange={setSearchOpen}
                 >
-                  <Search
+                  <SearchInput
                     placeholder="Type keyword to search"
                     enterButton="Search"
                     onSearch={(value) => {

--- a/web/src/pages/Cluster/components/index/overview/shards.jsx
+++ b/web/src/pages/Cluster/components/index/overview/shards.jsx
@@ -10,7 +10,7 @@ import { formatter } from "@/utils/format";
 import { filterSearchValue, sorter, formatUtcTimeToLocal } from "@/utils/utils";
 import { formatTimeRange } from "@/lib/elasticsearch/util";
 
-const { Search } = Input;
+import SearchInput from "@/components/infini/SearchInput";
 
 const Shards = ({
   clusterID,
@@ -161,7 +161,7 @@ const Shards = ({
           }}
         >
           <div style={{ maxWidth: 500, flex: "1 1 auto" }}>
-            <Search
+            <SearchInput
               allowClear
               placeholder="Type keyword to search"
               enterButton="Search"

--- a/web/src/pages/Cluster/components/node/nodes.jsx
+++ b/web/src/pages/Cluster/components/node/nodes.jsx
@@ -33,7 +33,7 @@ import { FilteredTags } from "../filtered_tags";
 import { HealthStatusCircle } from "@/components/infini/health_status_circle";
 import Sorter from "@/components/infini/search/sort/sort";
 
-const { Search } = Input;
+import SearchInput from "@/components/infini/SearchInput";
 const InputGroup = Input.Group;
 const Option = Select.Option;
 const filterWidth = 120;
@@ -350,7 +350,7 @@ const Nodes = (props) => {
                   open={searchOpen}
                   onDropdownVisibleChange={setSearchOpen}
                 >
-                  <Search
+                  <SearchInput
                     placeholder="Type keyword to search"
                     enterButton="Search"
                     onSearch={(value) => {

--- a/web/src/pages/Cluster/components/node/overview/shards.jsx
+++ b/web/src/pages/Cluster/components/node/overview/shards.jsx
@@ -10,7 +10,7 @@ import { formatter } from "@/utils/format";
 import { filterSearchValue, sorter, formatUtcTimeToLocal } from "@/utils/utils";
 import { formatTimeRange } from "@/lib/elasticsearch/util";
 
-const { Search } = Input;
+import SearchInput from "@/components/infini/SearchInput";
 
 const Shards = ({ clusterID, clusterName, nodeID, timeRange, setSpinning }) => {
   if (!clusterID || !nodeID) {
@@ -148,7 +148,7 @@ const Shards = ({ clusterID, clusterName, nodeID, timeRange, setSpinning }) => {
           }}
         >
           <div style={{ maxWidth: 500, flex: "1 1 auto" }}>
-            <Search
+            <SearchInput
               allowClear
               placeholder="Type keyword to search"
               enterButton="Search"

--- a/web/src/pages/Cluster/components/node/overview/statistic_bar.jsx
+++ b/web/src/pages/Cluster/components/node/overview/statistic_bar.jsx
@@ -6,6 +6,7 @@ import { formatUtcTimeToLocal } from "@/utils/utils";
 import moment from "moment";
 import { HealthStatusCircle } from "@/components/infini/health_status_circle";
 import OverviewStatistic from "../../overview_statistic";
+import { formatMessage } from "umi/locale";
 
 const vstyle = {
   fontSize: 12,
@@ -44,7 +45,7 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
       {
         key: "Status",
         value: nodeValue?.status || "N/A",
-        title: "Status",
+        title: formatMessage({ id: "overview.column.status" }),
         vstyle: {
           ...vstyle,
           display: "flex",
@@ -57,39 +58,41 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
         value: nodeValue?.jvm?.uptime
           ? moment.duration(nodeValue?.jvm?.uptime).humanize()
           : "N/A",
-        title: "Uptime",
+        title: formatMessage({ id: "overview.column.uptime" }),
       },
       {
         key: "Type",
-        value: nodeValue?.is_master_node ? "Master Node" : "Not Master Node",
-        title: "Type",
+        value: nodeValue?.is_master_node
+          ? formatMessage({ id: "overview.statistic.master_node" })
+          : formatMessage({ id: "overview.statistic.not_master_node" }),
+        title: formatMessage({ id: "overview.statistic.type" }),
       },
       {
         key: "Transport Address",
         value: nodeValue?.transport_address || "N/A",
-        title: "Transport Address",
+        title: formatMessage({ id: "overview.column.transport_address" }),
       },
       {
         key: "Indices",
         value: nodeValue?.shard_info?.indices_count,
-        title: "Indices",
+        title: formatMessage({ id: "overview.column.indices" }),
       },
       {
         key: "Shards",
         value:
           (nodeValue?.shard_info?.shard_count || 0) +
           (nodeValue?.shard_info?.replicas_count || 0),
-        title: "Shards",
+        title: formatMessage({ id: "overview.column.shards" }),
       },
       {
         key: "Documents",
         value: formatter.number(nodeValue?.indices?.docs?.count || 0),
-        title: "Documents",
+        title: formatMessage({ id: "indices.field.docs_count" }),
       },
       {
         key: "Data",
         value: formatter.bytes(nodeValue?.indices?.store?.size_in_bytes || 0),
-        title: "Data",
+        title: formatMessage({ id: "overview.column.data" }),
       },
       {
         key: "JVM Heap",
@@ -104,7 +107,7 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
             : 0
           ).toFixed(2) +
           "%)",
-        title: "JVM Heap",
+        title: formatMessage({ id: "overview.column.jvm_heap" }),
       },
       {
         key: "Free Disk Space",
@@ -117,7 +120,7 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
             : 0
           ).toFixed(2) +
           "%)",
-        title: "Free Disk Space",
+        title: formatMessage({ id: "overview.column.disk_free_space" }),
       },
     ];
   }
@@ -126,10 +129,14 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
       {!isAvailable ? (
         <div className={"mask"}>
           <div>
-            Node is not availabe since:{" "}
-            {nodeValue?.timestamp
-              ? formatUtcTimeToLocal(nodeValue?.timestamp)
-              : "N/A"}
+            {formatMessage(
+              { id: "overview.status.node_since" },
+              {
+                timestamp: nodeValue?.timestamp
+                  ? formatUtcTimeToLocal(nodeValue?.timestamp)
+                  : "N/A",
+              }
+            )}
           </div>
         </div>
       ) : null}

--- a/web/src/pages/Platform/Overview/Cluster/Detail/Infos.js
+++ b/web/src/pages/Platform/Overview/Cluster/Detail/Infos.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { ESPrefix } from "@/services/common";
 import Infos from "@/components/Overview/Detail/Infos";
+import { formatMessage } from "umi/locale";
 
 export default (props)=>{
   const id = props.data?._id
@@ -10,7 +11,7 @@ export default (props)=>{
 
   return (
     <Infos
-      header="Cluster Info"
+      header={formatMessage({ id: "overview.info.cluster" })}
       action={`${ESPrefix}/${id}/info`}
     />
   )

--- a/web/src/pages/Platform/Overview/Cluster/Detail/MetricTopN.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Detail/MetricTopN.jsx
@@ -1,8 +1,30 @@
 import React, { useState } from "react";
 import { Spin, Empty } from 'antd';
+import { formatMessage } from "umi/locale";
 import { ESPrefix } from "@/services/common";
 import useFetch from "@/lib/hooks/use_fetch";
 import Treemap from "@/components/infini/charts/Treemap";
+
+const TREEMAP_TITLE_MAP = {
+  "Search latency by index": "cluster.monitor.treemap.search_latency_by_index",
+  "Avg search latency by index": "cluster.monitor.treemap.search_latency_by_index",
+};
+
+const getLocalizedTreemapTitle = (title) => {
+  if (!title) {
+    return title;
+  }
+
+  const localeId = TREEMAP_TITLE_MAP[title];
+  if (!localeId) {
+    return title;
+  }
+
+  return formatMessage({
+    id: localeId,
+    defaultMessage: title,
+  });
+};
 
 export const MetricTopN = (props) => {
   const clusterID = props.data?._id || null;
@@ -19,7 +41,7 @@ export const MetricTopN = (props) => {
   return (
     <div>
       <div style={{ marginTop: "10px", marginBottom: "10px" }}>
-        <div>{treemapResult?._source?.name}</div>
+        <div>{getLocalizedTreemapTitle(treemapResult?._source?.name)}</div>
         {treemapData.children ? (
           <Treemap
             data={treemapData}

--- a/web/src/pages/Platform/Overview/Cluster/Detail/Metrics.js
+++ b/web/src/pages/Platform/Overview/Cluster/Detail/Metrics.js
@@ -13,19 +13,19 @@ export default (props) => {
   }
 
   const overviews = [
-    { 
-      key: 'nodes', 
-      title: 'Nodes', 
+    {
+      key: "nodes",
+      titleId: "overview.title.node",
       action: `${ESPrefix}/${clusterID}/nodes`,
-      component: MetricNodes 
+      component: MetricNodes,
     },
-    { 
-      key: 'indices', 
-      title: 'Indices', 
+    {
+      key: "indices",
+      titleId: "overview.title.index",
       action: `${ESPrefix}/${clusterID}/indices`,
-      component: MetricIndices 
-    }
-  ]
+      component: MetricIndices,
+    },
+  ];
 
   return (
     <Metrics
@@ -33,8 +33,13 @@ export default (props) => {
       params={{ clusterID, clusterName }}
       linkMore={`/cluster/monitor/elasticsearch/${clusterID}`}
       overviews={overviews}
-      metrics={['index_throughput', 'search_throughput', 'index_latency', 'search_latency']}
+      metrics={[
+        "index_throughput",
+        "search_throughput",
+        "index_latency",
+        "search_latency",
+      ]}
     />
-  )
+  );
 
 };

--- a/web/src/pages/Platform/Overview/Cluster/Monitor/indices.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Monitor/indices.jsx
@@ -96,7 +96,7 @@ const Indices = ({
   const [columns] = useMemo(() => {
     let columns = [
       {
-        title: "Name",
+        title: formatMessage({ id: "overview.column.name" }),
         dataIndex: "index",
         render: (text, record) => (
           <IconText
@@ -118,36 +118,36 @@ const Indices = ({
         className: commonStyles.maxColumnWidth
       },
       {
-        title: "Health",
+        title: formatMessage({ id: "overview.column.health" }),
         dataIndex: "health",
         render: (text, record) => <HealthStatusView status={record?.health} />,
         sorter: (a, b) => sorter.string(a, b, "health"),
       },
       {
-        title: "Status",
+        title: formatMessage({ id: "overview.column.status" }),
         dataIndex: "status",
         sorter: (a, b) => sorter.string(a, b, "status"),
       },
       {
-        title: "Shards",
+        title: formatMessage({ id: "overview.column.shards" }),
         dataIndex: "shards",
         render: (text, record) => <span>{text || 0}</span>,
         sorter: (a, b) => a?.shards - b?.shards,
       },
       {
-        title: "Replicas",
+        title: formatMessage({ id: "overview.column.replicas" }),
         dataIndex: "replicas",
         render: (text, record) => <span>{text || 0}</span>,
         sorter: (a, b) => a?.replicas - b?.replicas,
       },
       {
-        title: "Document Count",
+        title: formatMessage({ id: "overview.column.document_count" }),
         dataIndex: "docs_count",
         render: (text, record) => <span>{formatter.number(text || 0)}</span>,
         sorter: (a, b) => a?.docs_count - b?.docs_count,
       },
       {
-        title: "Data",
+        title: formatMessage({ id: "overview.column.data" }),
         dataIndex: "store_size_bytes",
         render: (text, record) => <span>{record?.store_size || 0}</span>,
         sorter: (a, b) => a?.store_size_bytes - b?.store_size_bytes,
@@ -155,7 +155,7 @@ const Indices = ({
     ];
     if (showRealtime) {
       columns.push({
-        title: "Pri Indexing Rate",
+        title: formatMessage({ id: "overview.column.primary_indexing_rate" }),
         dataIndex: "index_qps",
         render: (text, record) => (
           <span>{text != null ? `${text} /s` : "N/A"}</span>
@@ -163,7 +163,7 @@ const Indices = ({
         sorter: (a, b) => a?.index_qps - b?.index_qps,
       });
       columns.push({
-        title: "Pri Indexing Bytes",
+        title: formatMessage({ id: "overview.column.primary_indexing_bytes" }),
         dataIndex: "index_bytes_qps",
         render: (text, record) => (
           <span>
@@ -173,7 +173,7 @@ const Indices = ({
         sorter: (a, b) => a?.index_bytes_qps - b?.index_bytes_qps,
       });
       columns.push({
-        title: "Search Rate",
+        title: formatMessage({ id: "overview.column.search_rate" }),
         dataIndex: "query_qps",
         render: (text, record) => (
           <span>{text != null ? `${text} /s` : "N/A"}</span>
@@ -182,7 +182,7 @@ const Indices = ({
       });
     } else {
       columns.push({
-        title: "Timestamp",
+        title: formatMessage({ id: "overview.column.timestamp" }),
         dataIndex: "timestamp",
         render: (text, record) => <span>{formatUtcTimeToLocal(text)}</span>,
         sorter: (a, b) => sorter.string(a, b, "timestamp"),

--- a/web/src/pages/Platform/Overview/Cluster/Monitor/nodes.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Monitor/nodes.jsx
@@ -93,7 +93,7 @@ export default ({
   const [columns] = React.useMemo(() => {
     let columns = [
       {
-        title: "Name",
+        title: formatMessage({ id: "overview.column.name" }),
         dataIndex: "name",
         render: (text, record) => (
           <span>
@@ -134,7 +134,7 @@ export default ({
     ];
     if (showRealtime) {
       columns.push({
-        title: "Status",
+        title: formatMessage({ id: "overview.column.status" }),
         dataIndex: "status",
         render: (text, record) => (
           <HealthStatusView status={text ?? "available"} />
@@ -145,14 +145,14 @@ export default ({
     }
     columns = columns.concat([
       {
-        title: "Shards",
+        title: formatMessage({ id: "overview.column.shards" }),
         dataIndex: "shards",
         render: (text, record) => <span>{text || "N/A"}</span>,
         sorter: (a, b) => a?.shards - b?.shards,
         className: "verticalAlign",
       },
       {
-        title: "CPU Usage",
+        title: formatMessage({ id: "overview.column.cpu_usage" }),
         dataIndex: "cpu",
         render: (text, record) => {
           const number = parseFloat(text);
@@ -168,7 +168,7 @@ export default ({
         className: "verticalAlign",
       },
       {
-        title: "Load Average",
+        title: formatMessage({ id: "overview.column.load_average" }),
         dataIndex: "load_1m",
         render: (text, record) => (
           <span>
@@ -179,7 +179,7 @@ export default ({
         className: "verticalAlign",
       },
       {
-        title: "JVM Heap",
+        title: formatMessage({ id: "overview.column.jvm_heap" }),
         dataIndex: "heap.percent",
         render: (text, record) => {
           const number = parseFloat(text);
@@ -195,14 +195,14 @@ export default ({
         className: "verticalAlign",
       },
       {
-        title: "Disk Free Space",
+        title: formatMessage({ id: "overview.column.disk_free_space" }),
         dataIndex: "disk_avail_bytes",
         render: (text, record) => <span>{record["disk.avail"] || "N/A"}</span>,
         sorter: (a, b) => a?.disk_avail_bytes - b?.disk_avail_bytes,
         className: "verticalAlign",
       },
       {
-        title: "Disk Used Space",
+        title: formatMessage({ id: "overview.column.disk_used_space" }),
         dataIndex: "disk_used_bytes",
         render: (text, record) => <span>{record["disk.used"] || "N/A"}</span>,
         sorter: (a, b) => a?.disk_used_bytes - b?.disk_used_bytes,
@@ -211,14 +211,14 @@ export default ({
     ]);
     if (showRealtime) {
       columns.push({
-        title: "Uptime",
+        title: formatMessage({ id: "overview.column.uptime" }),
         dataIndex: "uptime_ms",
         render: (text, record) => <span>{record["uptime"] || "N/A"}</span>,
         sorter: (a, b) => a?.uptime_ms - b?.uptime_ms,
         className: "verticalAlign",
       });
       columns.push({
-        title: "Indexing Rate",
+        title: formatMessage({ id: "overview.column.indexing_rate" }),
         dataIndex: "index_qps",
         render: (text, record) => (
           <span>{text != null ? `${text} /s` : "N/A"}</span>
@@ -227,7 +227,7 @@ export default ({
         className: "verticalAlign",
       });
       columns.push({
-        title: "Indexing Bytes",
+        title: formatMessage({ id: "overview.column.indexing_bytes" }),
         dataIndex: "index_bytes_qps",
         render: (text, record) => (
           <span>
@@ -238,7 +238,7 @@ export default ({
         className: "verticalAlign",
       });
       columns.push({
-        title: "Search Rate",
+        title: formatMessage({ id: "overview.column.search_rate" }),
         dataIndex: "query_qps",
         render: (text, record) => (
           <span>{text != null ? `${text} /s` : "N/A"}</span>
@@ -248,7 +248,7 @@ export default ({
       });
     } else {
       columns.push({
-        title: "Timestamp",
+        title: formatMessage({ id: "overview.column.timestamp" }),
         dataIndex: "timestamp",
         render: (text, record) => <span>{formatUtcTimeToLocal(text)}</span>,
         sorter: (a, b) => sorter.string(a, b, "timestamp"),

--- a/web/src/pages/Platform/Overview/Cluster/Table/index.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Table/index.jsx
@@ -14,7 +14,7 @@ export default (props) => {
       {...props}
       columns={[
         {
-          title: "Name",
+          title: formatMessage({ id: "overview.column.name" }),
           dataIndex: "name",
           render: (text, record) => {
             return (
@@ -55,14 +55,14 @@ export default (props) => {
           },
         },
         {
-          title: "Version",
+          title: formatMessage({ id: "overview.column.version" }),
           dataIndex: "version",
           render: (text, record) => {
             return record.metadata?.version ?? "";
           },
         },
         {
-          title: "Health",
+          title: formatMessage({ id: "overview.column.health" }),
           dataIndex: "health_status",
           render: (text, record) => {
             return (
@@ -98,28 +98,28 @@ export default (props) => {
           },
         },
         {
-          title: "Nodes",
+          title: formatMessage({ id: "overview.column.nodes" }),
           dataIndex: "nodes",
           render: (text, record) => {
             return record.summary?.number_of_nodes || 0;
           },
         },
         {
-          title: "Indices",
+          title: formatMessage({ id: "overview.column.indices" }),
           dataIndex: "Indices",
           render: (text, record) => {
             return record.summary?.number_of_indices || 0;
           },
         },
         {
-          title: "Shards",
+          title: formatMessage({ id: "overview.column.shards" }),
           dataIndex: "Shards",
           render: (text, record) => {
             return record.summary?.number_of_shards || 0;
           },
         },
         {
-          title: "Docs",
+          title: formatMessage({ id: "overview.column.docs" }),
           dataIndex: "Docs",
           render: (text, record) => {
             return (
@@ -134,7 +134,7 @@ export default (props) => {
           },
         },
         {
-          title: "Disk Usage",
+          title: formatMessage({ id: "overview.column.disk_usage" }),
           dataIndex: "DiskUsage",
           render: (text, record) => {
             return (
@@ -161,7 +161,7 @@ export default (props) => {
           },
         },
         {
-          title: "JVM Heap",
+          title: formatMessage({ id: "overview.column.jvm_heap" }),
           dataIndex: "JVMHeap",
           render: (text, record) => {
             return (

--- a/web/src/pages/Platform/Overview/Cluster/index.tsx
+++ b/web/src/pages/Platform/Overview/Cluster/index.tsx
@@ -24,9 +24,24 @@ const aggsParams = [
 ];
 
 const details = [
-  { title: "Metrics", component: Metrics, key: "metrics" },
-  { title: "TopN", component: MetricTopN, key: "topN" },
-  { title: "Infos", component: Infos, key: "infos" },
+  {
+    title: "Metrics",
+    titleId: "overview.detail.metrics",
+    component: Metrics,
+    key: "metrics",
+  },
+  {
+    title: "TopN",
+    titleId: "cluster.monitor.tabs.topn",
+    component: MetricTopN,
+    key: "topN",
+  },
+  {
+    title: "Infos",
+    titleId: "overview.detail.infos",
+    component: Infos,
+    key: "infos",
+  },
 ];
 
 const sideSorterOptions = [

--- a/web/src/pages/Platform/Overview/Host/Detail/Metrics.js
+++ b/web/src/pages/Platform/Overview/Host/Detail/Metrics.js
@@ -83,12 +83,12 @@ const Agent = (props) => {
       title={formatMessage({ id: "host.detail.agent.title" })}
       action={`/host/${props.id}/agent/info`}
       rowKey="agent_id"
-      columns={[
-        {
-          title: "Endpoint",
-          dataIndex: "endpoint",
-          key: "endpoint",
-        },
+        columns={[
+          {
+            title: formatMessage({ id: "overview.column.endpoint" }),
+            dataIndex: "endpoint",
+            key: "endpoint",
+          },
         {
           title: formatMessage({ id: "host.detail.table.column.status" }),
           dataIndex: "status",
@@ -136,12 +136,12 @@ const Process = (props) => {
       title={formatMessage({ id: "host.detail.processes.title" })}
       action={`/host/${props.id}/processes`}
       rowKey="pid"
-      columns={[
-        {
-          title: "PID",
-          dataIndex: "pid",
-          key: "pid",
-        },
+        columns={[
+          {
+            title: formatMessage({ id: "overview.column.pid" }),
+            dataIndex: "pid",
+            key: "pid",
+          },
         {
           title: formatMessage({ id: "host.detail.table.column.cluster" }),
           dataIndex: "cluster_name",

--- a/web/src/pages/Platform/Overview/Host/Monitor/process.jsx
+++ b/web/src/pages/Platform/Overview/Host/Monitor/process.jsx
@@ -11,7 +11,7 @@ import { filterSearchValue, sorter, formatUtcTimeToLocal } from "@/utils/utils";
 import { formatTimeRange } from "@/lib/elasticsearch/util";
 import moment from 'moment';
 
-const { Search } = Input;
+import SearchInput from "@/components/infini/SearchInput";
 
 export default ({ hostID }) => {
   const [searchValue, setSearchValue] = React.useState("");
@@ -63,23 +63,23 @@ export default ({ hostID }) => {
 
   const columns = [
     {
-      title: "PID",
+      title: formatMessage({ id: "overview.column.pid" }),
       dataIndex: "pid",
     },
     {
-      title: "Cluster",
+      title: formatMessage({ id: "overview.column.cluster" }),
       dataIndex: "cluster_name",
     },
     {
-      title: "Node",
+      title: formatMessage({ id: "overview.column.node" }),
       dataIndex: "node_name",
     },
     {
-      title: "Status",
+      title: formatMessage({ id: "overview.column.status" }),
       dataIndex: "pid_status",
     },
     {
-      title: "UpTime",
+      title: formatMessage({ id: "overview.column.uptime" }),
       dataIndex: "uptime_in_ms",
       render: (text) => moment.duration(text, "ms").humanize(),
     },
@@ -96,7 +96,7 @@ export default ({ hostID }) => {
         }}
       >
         <div style={{ maxWidth: 500, flex: "1 1 auto" }}>
-          <Search
+          <SearchInput
             allowClear
             placeholder="Type keyword to search"
             enterButton="Search"

--- a/web/src/pages/Platform/Overview/Host/Table/index.jsx
+++ b/web/src/pages/Platform/Overview/Host/Table/index.jsx
@@ -67,7 +67,7 @@ export default (props) => {
   const [columns] = useMemo(() => {
     let columns = [
       {
-        title: "Transport Address",
+        title: formatMessage({ id: "overview.column.transport_address" }),
         dataIndex: "host",
         render: (text, record) => {
           return (
@@ -93,7 +93,7 @@ export default (props) => {
         },
       },
       {
-        title: "Status",
+        title: formatMessage({ id: "overview.column.status" }),
         dataIndex: "host_status",
         render: (text, record) => {
           return (
@@ -120,7 +120,7 @@ export default (props) => {
         },
       },
       {
-        title: "Host Name",
+        title: formatMessage({ id: "overview.column.host_name" }),
         dataIndex: "host_name",
         render: (text, record) => {
           return (
@@ -137,7 +137,7 @@ export default (props) => {
         },
       },
       {
-        title: "Agent Status",
+        title: formatMessage({ id: "overview.column.agent_status" }),
         dataIndex: "agent_status",
         render: (text, record) => {
           return (
@@ -149,7 +149,7 @@ export default (props) => {
         },
       },
       {
-        title: "CPU Usage",
+        title: formatMessage({ id: "overview.column.cpu_usage" }),
         dataIndex: "CPU Usage",
         render: (text, record) => {
           return (
@@ -164,7 +164,7 @@ export default (props) => {
         },
       },
       {
-        title: "Disk Usage",
+        title: formatMessage({ id: "overview.column.disk_usage" }),
         dataIndex: "DiskUsage",
         render: (text, record) => {
           return (
@@ -191,7 +191,7 @@ export default (props) => {
         },
       },
       {
-        title: "JVM Heap",
+        title: formatMessage({ id: "overview.column.jvm_heap" }),
         dataIndex: "JVMHeap",
         render: (text, record) => {
           return (
@@ -229,6 +229,7 @@ export default (props) => {
         loading={loading}
         columns={columns}
         dataSource={tableData}
+        scroll={{ x: "max-content" }}
         rowKey={"id"}
         pagination={{
           size: "small",

--- a/web/src/pages/Platform/Overview/Host/index.tsx
+++ b/web/src/pages/Platform/Overview/Host/index.tsx
@@ -24,9 +24,24 @@ const aggsParams = [
 ];
 
 const details = [
-  { title: "Metrics", component: Metrics, key: "metrics" },
-  { title: "Infos", component: Infos, key: "infos" },
-  { title: "Edit", component: Edit, key: "edit" },
+  {
+    title: "Metrics",
+    titleId: "overview.detail.metrics",
+    component: Metrics,
+    key: "metrics",
+  },
+  {
+    title: "Infos",
+    titleId: "overview.detail.infos",
+    component: Infos,
+    key: "infos",
+  },
+  {
+    title: "Edit",
+    titleId: "form.button.edit",
+    component: Edit,
+    key: "edit",
+  },
 ];
 
 const sideSorterOptions = [

--- a/web/src/pages/Platform/Overview/Indices/Detail/Infos.js
+++ b/web/src/pages/Platform/Overview/Indices/Detail/Infos.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { ESPrefix } from "@/services/common";
 import Infos from "@/components/Overview/Detail/Infos";
+import { formatMessage } from "umi/locale";
 
 export default (props) => {
   const indexID = props.data?._source?.metadata?.index_id;
@@ -32,7 +33,7 @@ export default (props) => {
 
   return (
     <Infos
-      header="Index Info"
+      header={formatMessage({ id: "overview.info.index" })}
       action={`${ESPrefix}/${clusterID}/index/${indexID}/info`}
       formatInfo={formatInfo}
     />

--- a/web/src/pages/Platform/Overview/Indices/Detail/Metrics.js
+++ b/web/src/pages/Platform/Overview/Indices/Detail/Metrics.js
@@ -12,13 +12,13 @@ export default (props) => {
   }
 
   const overviews = [
-    { 
-      key: 'nodes', 
-      title: 'Nodes', 
+    {
+      key: "nodes",
+      titleId: "overview.title.node",
       action: `${ESPrefix}/${clusterID}/index/${indexName}/nodes`,
-      component: MetricNodes 
-    }
-  ]
+      component: MetricNodes,
+    },
+  ];
 
   return (
     <Metrics
@@ -33,5 +33,5 @@ export default (props) => {
         "search_latency",
       ]}
     />
-  )
+  );
 };

--- a/web/src/pages/Platform/Overview/Indices/Monitor/shard_statistic_bar.jsx
+++ b/web/src/pages/Platform/Overview/Indices/Monitor/shard_statistic_bar.jsx
@@ -3,6 +3,7 @@ import useFetch from "@/lib/hooks/use_fetch";
 import { ESPrefix } from "@/services/common";
 import { HealthStatusCircle } from "@/components/infini/health_status_circle";
 import OverviewStatistic from "../../components/overview_statistic";
+import { formatMessage } from "umi/locale";
 import { formatUtcTimeToLocal, formatt } from "@/utils/utils";
 import {formatter} from "@/utils/format";
 
@@ -39,37 +40,37 @@ const StatisticBar = ({ clusterID, indexName, timeRange, setSpinning, shardID, }
     overviewStatistic = [
       {
         key: "shard",
-        title: "Shard",
+        title: formatMessage({ id: "overview.column.shard" }),
         value: shardValue.metadata.labels.shard,
       },
       {
         key: "state",
-        title: "State",
+        title: formatMessage({ id: "overview.column.state" }),
         value: shardValue?.payload?.elasticsearch?.shard_stats.routing.state || "N/A",
       },
       {
         key: "node",
-        title: "node",
+        title: formatMessage({ id: "overview.column.node" }),
         value: nodeV,
       },
       {
         key: "primary",
-        title: "Primary",
+        title: formatMessage({ id: "overview.statistic.primary" }),
         value: shardValue?.payload?.elasticsearch?.shard_stats.routing.primary,
       },
       {
         key: "Documents",
-        title: "Documents",
+        title: formatMessage({ id: "indices.field.docs_count" }),
         value: shardValue?.payload?.elasticsearch?.shard_stats?.docs.count || "N/A",
       },
       {
         key: "store",
-        title: "Store",
+        title: formatMessage({ id: "overview.column.store" }),
         value: formatter.bytes(shardValue?.payload?.elasticsearch?.shard_stats.store?.size_in_bytes || 0) || "N/A",
       },
       {
         key: "Updated",
-        title: "Updated",
+        title: formatMessage({ id: "overview.statistic.updated" }),
         value: shardValue?.timestamp
           ? formatUtcTimeToLocal(shardValue?.timestamp)
           : "N/A",

--- a/web/src/pages/Platform/Overview/Indices/Monitor/shards.jsx
+++ b/web/src/pages/Platform/Overview/Indices/Monitor/shards.jsx
@@ -13,7 +13,6 @@ import IconText from "@/components/infini/IconText";
 import AutoTextEllipsis from "@/components/AutoTextEllipsis";
 import commonStyles from "@/common.less"
 
-const { Search } = Input;
 
 export default ({
   clusterID,
@@ -88,7 +87,7 @@ export default ({
   const [columns] = React.useMemo(() => {
     let columns = [
       {
-        title: "Shard",
+        title: formatMessage({ id: "overview.column.shard" }),
         dataIndex: "shard",
         render: (text, record) => {
           if (!record.shard_id) {
@@ -111,7 +110,7 @@ export default ({
         sorter: (a, b) => a?.shard - b?.shard,
       },
       {
-        title: "Prirep",
+        title: formatMessage({ id: "overview.column.prirep" }),
         dataIndex: "prirep",
         render: (text, record) => (
           <span>
@@ -125,12 +124,12 @@ export default ({
         sorter: (a, b) => sorter.string(a, b, "prirep"),
       },
       {
-        title: "IP",
+        title: formatMessage({ id: "overview.column.ip" }),
         dataIndex: "ip",
         sorter: (a, b) => sorter.string(a, b, "ip"),
       },
       {
-        title: "Node",
+        title: formatMessage({ id: "overview.column.node" }),
         dataIndex: "node",
         render: (text, record) => {
           if (!text) {
@@ -159,12 +158,12 @@ export default ({
         className: commonStyles.maxColumnWidth
       },
       {
-        title: "State",
+        title: formatMessage({ id: "overview.column.state" }),
         dataIndex: "state",
         sorter: (a, b) => sorter.string(a, b, "state"),
       },
       {
-        title: "Docs",
+        title: formatMessage({ id: "overview.column.docs" }),
         dataIndex: "docs",
         render: (text, record) => (
           <span>{formatter.number(record?.docs || 0)}</span>
@@ -172,7 +171,7 @@ export default ({
         sorter: (a, b) => a?.docs - b?.docs,
       },
       {
-        title: "Store",
+        title: formatMessage({ id: "overview.column.store" }),
         dataIndex: "store_size_bytes",
         render: (text, record) => (
           <span>{formatter.bytes(record?.store_in_bytes || 0)}</span>
@@ -180,7 +179,7 @@ export default ({
         sorter: (a, b) => a?.store_in_bytes - b?.store_in_bytes,
       },
       {
-        title: "Indexing Rate",
+        title: formatMessage({ id: "overview.column.indexing_rate" }),
         dataIndex: "index_qps",
         render: (text, record) => (
           <span>{text != null ? `${text} /s` : "N/A"}</span>
@@ -188,7 +187,7 @@ export default ({
         sorter: (a, b) => a?.index_qps - b?.index_qps,
       },
       {
-        title: "Indexing Bytes",
+        title: formatMessage({ id: "overview.column.indexing_bytes" }),
         dataIndex: "index_bytes_qps",
         render: (text, record) => (
           <span>
@@ -212,7 +211,7 @@ export default ({
         }}
       >
         <div style={{ maxWidth: 500, flex: "1 1 auto" }}>
-          <Search
+          <Input.Search
             allowClear
             placeholder="Type keyword to search"
             enterButton="Search"

--- a/web/src/pages/Platform/Overview/Indices/Monitor/statistic_bar.jsx
+++ b/web/src/pages/Platform/Overview/Indices/Monitor/statistic_bar.jsx
@@ -5,6 +5,7 @@ import { formatter } from "@/utils/format";
 import { HealthStatusCircle } from "@/components/infini/health_status_circle";
 import OverviewStatistic from "../../components/overview_statistic";
 import { formatUtcTimeToLocal } from "@/utils/utils";
+import { formatMessage } from "umi/locale";
 
 const vstyle = {
   fontSize: 12,
@@ -41,7 +42,7 @@ const StatisticBar = ({ clusterID, indexName, timeRange, setSpinning }) => {
     overviewStatistic = [
       {
         key: "Health",
-        title: "Health",
+        title: formatMessage({ id: "indices.field.health" }),
         value: indexValue?.index_info?.health,
         vstyle: {
           ...vstyle,
@@ -52,37 +53,37 @@ const StatisticBar = ({ clusterID, indexName, timeRange, setSpinning }) => {
       },
       {
         key: "Status",
-        title: "Status",
+        title: formatMessage({ id: "indices.field.status" }),
         value: indexValue?.index_info?.status ?? "N/A",
       },
       {
         key: "Total",
-        title: "Total",
+        title: formatMessage({ id: "indices.field.store_size" }),
         value: indexValue?.index_info?.store_size?.toUpperCase() ?? "N/A",
       },
       {
         key: "Primaries",
-        title: "Primaries",
+        title: formatMessage({ id: "indices.field.primary_store_size" }),
         value: indexValue?.index_info?.pri_store_size?.toUpperCase() ?? "N/A",
       },
       {
         key: "Documents",
-        title: "Documents",
+        title: formatMessage({ id: "indices.field.docs_count" }),
         value: formatter.number(indexValue?.index_info?.docs_count || 0),
       },
       {
         key: "Total shards",
-        title: "Total shards",
+        title: formatMessage({ id: "overview.statistic.total_shards" }),
         value: indexValue?.index_info?.shards ?? "N/A",
       },
       {
         key: "Unassigned shards",
-        title: "Unassigned shards",
+        title: formatMessage({ id: "cluster.monitor.summary.unassign_shard" }),
         value: indexValue?.unassigned_shards ?? "N/A",
       },
       {
         key: "Updated",
-        title: "Updated",
+        title: formatMessage({ id: "overview.statistic.updated" }),
         value: indexValue?.timestamp
           ? formatUtcTimeToLocal(indexValue?.timestamp)
           : "N/A",
@@ -95,15 +96,20 @@ const StatisticBar = ({ clusterID, indexName, timeRange, setSpinning }) => {
       {!isAvailable ? (
         <div className={"mask"}>
           <div>
-            Index is{" "}
-            {indexValue?.index_info?.status == "delete" ||
-            indexValue?.index_info?.status == "close"
-              ? `${indexValue?.index_info?.status}d`
-              : "not availabe"}{" "}
-            since:{" "}
-            {indexValue?.timestamp
-              ? formatUtcTimeToLocal(indexValue?.timestamp)
-              : "N/A"}
+            {formatMessage(
+              { id: "overview.status.index_since" },
+              {
+                status:
+                  indexValue?.index_info?.status == "delete"
+                    ? formatMessage({ id: "overview.status.deleted" })
+                    : indexValue?.index_info?.status == "close"
+                      ? formatMessage({ id: "overview.status.closed" })
+                      : formatMessage({ id: "overview.status.unavailable" }),
+                timestamp: indexValue?.timestamp
+                  ? formatUtcTimeToLocal(indexValue?.timestamp)
+                  : "N/A",
+              }
+            )}
           </div>
         </div>
       ) : null}

--- a/web/src/pages/Platform/Overview/Indices/Table/index.jsx
+++ b/web/src/pages/Platform/Overview/Indices/Table/index.jsx
@@ -14,7 +14,7 @@ export default (props) => {
       {...props}
       columns={[
         {
-          title: "Name",
+          title: formatMessage({ id: "overview.column.name" }),
           dataIndex: "name",
           render: (text, record) => {
             return (
@@ -44,7 +44,7 @@ export default (props) => {
           },
         },
         {
-          title: "Health",
+          title: formatMessage({ id: "overview.column.health" }),
           dataIndex: "health_status",
           render: (text, record) => {
             return (
@@ -80,21 +80,21 @@ export default (props) => {
           },
         },
         {
-          title: "Status",
+          title: formatMessage({ id: "overview.column.status" }),
           dataIndex: "index_status",
           render: (text, record) => {
             return record.metadata?.labels?.state ?? "N/A";
           },
         },
         {
-          title: "Store Size",
+          title: formatMessage({ id: "overview.column.store_size" }),
           dataIndex: "store_size",
           render: (text, record) => {
             return record.summary?.index_info?.store_size?.toUpperCase() || "N/A";
           },
         },
         {
-          title: "Shards",
+          title: formatMessage({ id: "overview.column.shards" }),
           dataIndex: "Shards",
           render: (text, record) => {
             return (
@@ -120,7 +120,7 @@ export default (props) => {
           },
         },
         {
-          title: "Docs",
+          title: formatMessage({ id: "overview.column.docs" }),
           dataIndex: "Docs",
           render: (text, record) => {
             return (

--- a/web/src/pages/Platform/Overview/Indices/index.tsx
+++ b/web/src/pages/Platform/Overview/Indices/index.tsx
@@ -19,8 +19,18 @@ const aggsParams = [
 ];
 
 const details = [
-  { title: "Metrics", component: Metrics, key: "metrics" },
-  { title: "Infos", component: Infos, key: "infos" },
+  {
+    title: "Metrics",
+    titleId: "overview.detail.metrics",
+    component: Metrics,
+    key: "metrics",
+  },
+  {
+    title: "Infos",
+    titleId: "overview.detail.infos",
+    component: Infos,
+    key: "infos",
+  },
 ];
 
 const sideSorterOptions = [

--- a/web/src/pages/Platform/Overview/Node/Detail/Infos.js
+++ b/web/src/pages/Platform/Overview/Node/Detail/Infos.js
@@ -2,6 +2,7 @@ import React from "react";
 import { ESPrefix } from "@/services/common";
 import { formatter } from "@/utils/format";
 import Infos from "@/components/Overview/Detail/Infos";
+import { formatMessage } from "umi/locale";
 
 export default (props) => {
   const nodeID = props.data?._source?.metadata?.node_id;
@@ -44,7 +45,7 @@ export default (props) => {
 
   return (
     <Infos
-      header="Node Info"
+      header={formatMessage({ id: "overview.info.node" })}
       action={`${ESPrefix}/${clusterID}/node/${nodeID}/info`}
       formatInfo={formatInfo}
     />

--- a/web/src/pages/Platform/Overview/Node/Detail/Logs.js
+++ b/web/src/pages/Platform/Overview/Node/Detail/Logs.js
@@ -242,7 +242,6 @@ const Logs = (props) => {
           <div className="right">
             <Button
               loading={loading}
-              size="small"
               onClick={() => fetchLogs(true)}
             >
               {formatMessage({ id: "form.button.refresh" })}

--- a/web/src/pages/Platform/Overview/Node/Detail/Metrics.js
+++ b/web/src/pages/Platform/Overview/Node/Detail/Metrics.js
@@ -15,7 +15,7 @@ export default (props) => {
   const overviews = [
     {
       key: "indices",
-      title: "Indices",
+      titleId: "overview.title.index",
       action: `${ESPrefix}/${clusterID}/node/${nodeID}/indices`,
       component: MetricIndices,
     },

--- a/web/src/pages/Platform/Overview/Node/Monitor/shards.jsx
+++ b/web/src/pages/Platform/Overview/Node/Monitor/shards.jsx
@@ -13,7 +13,6 @@ import IconText from "@/components/infini/IconText";
 import AutoTextEllipsis from "@/components/AutoTextEllipsis";
 import commonStyles from "@/common.less"
 
-const { Search } = Input;
 
 export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
   const [searchValue, setSearchValue] = React.useState("");
@@ -85,7 +84,7 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
   const [columns] = React.useMemo(() => {
     let columns = [
       {
-        title: "Index",
+        title: formatMessage({ id: "overview.column.index" }),
         dataIndex: "index",
         render: (text, record) => {
           return (
@@ -109,7 +108,7 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
         className: commonStyles.maxColumnWidth
       },
       {
-        title: "Shard",
+        title: formatMessage({ id: "overview.column.shard" }),
         dataIndex: "shard",
         render: (text, record) => {
           if (!record.shard_id) {
@@ -132,7 +131,7 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
         sorter: (a, b) => a?.shard - b?.shard,
       },
       {
-        title: "Prirep",
+        title: formatMessage({ id: "overview.column.prirep" }),
         dataIndex: "prirep",
         render: (text, record) => (
           <span>
@@ -146,12 +145,12 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
         sorter: (a, b) => sorter.string(a, b, "prirep"),
       },
       {
-        title: "State",
+        title: formatMessage({ id: "overview.column.state" }),
         dataIndex: "state",
         sorter: (a, b) => sorter.string(a, b, "state"),
       },
       {
-        title: "Docs",
+        title: formatMessage({ id: "overview.column.docs" }),
         dataIndex: "docs",
         render: (text, record) => (
           <span>{formatter.number(record?.docs || 0)}</span>
@@ -159,7 +158,7 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
         sorter: (a, b) => a?.docs - b?.docs,
       },
       {
-        title: "Store",
+        title: formatMessage({ id: "overview.column.store" }),
         dataIndex: "store_size_bytes",
         render: (text, record) => (
           <span>{formatter.bytes(record?.store_in_bytes || 0)}</span>
@@ -167,7 +166,7 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
         sorter: (a, b) => a?.store_in_bytes - b?.store_in_bytes,
       },
       {
-        title: "Indexing Rate",
+        title: formatMessage({ id: "overview.column.indexing_rate" }),
         dataIndex: "index_qps",
         render: (text, record) => (
           <span>{text != null ? `${text} /s` : "N/A"}</span>
@@ -175,7 +174,7 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
         sorter: (a, b) => a?.index_qps - b?.index_qps,
       },
       {
-        title: "Indexing Bytes",
+        title: formatMessage({ id: "overview.column.indexing_bytes" }),
         dataIndex: "index_bytes_qps",
         render: (text, record) => (
           <span>
@@ -199,7 +198,7 @@ export default ({ clusterID, clusterName, nodeID, timeRange, bucketSize }) => {
         }}
       >
         <div style={{ maxWidth: 500, flex: "1 1 auto" }}>
-          <Search
+          <Input.Search
             allowClear
             placeholder="Type keyword to search"
             enterButton="Search"

--- a/web/src/pages/Platform/Overview/Node/Monitor/statistic_bar.jsx
+++ b/web/src/pages/Platform/Overview/Node/Monitor/statistic_bar.jsx
@@ -6,6 +6,7 @@ import { formatUtcTimeToLocal } from "@/utils/utils";
 import moment from "moment";
 import { HealthStatusCircle } from "@/components/infini/health_status_circle";
 import OverviewStatistic from "../../components/overview_statistic";
+import { formatMessage } from "umi/locale";
 
 const vstyle = {
   fontSize: 12,
@@ -44,7 +45,7 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
       {
         key: "Status",
         value: nodeValue?.status || "N/A",
-        title: "Status",
+        title: formatMessage({ id: "overview.column.status" }),
         vstyle: {
           ...vstyle,
           display: "flex",
@@ -57,39 +58,41 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
         value: nodeValue?.jvm?.uptime
           ? moment.duration(nodeValue?.jvm?.uptime).humanize()
           : "N/A",
-        title: "Uptime",
+        title: formatMessage({ id: "overview.column.uptime" }),
       },
       {
         key: "Type",
-        value: nodeValue?.is_master_node ? "Master Node" : "Not Master Node",
-        title: "Type",
+        value: nodeValue?.is_master_node
+          ? formatMessage({ id: "overview.statistic.master_node" })
+          : formatMessage({ id: "overview.statistic.not_master_node" }),
+        title: formatMessage({ id: "overview.statistic.type" }),
       },
       {
         key: "Transport Address",
         value: nodeValue?.transport_address || "N/A",
-        title: "Transport Address",
+        title: formatMessage({ id: "overview.column.transport_address" }),
       },
       {
         key: "Indices",
         value: nodeValue?.shard_info?.indices_count,
-        title: "Indices",
+        title: formatMessage({ id: "overview.column.indices" }),
       },
       {
         key: "Shards",
         value:
           (nodeValue?.shard_info?.shard_count || 0) +
           (nodeValue?.shard_info?.replicas_count || 0),
-        title: "Shards",
+        title: formatMessage({ id: "overview.column.shards" }),
       },
       {
         key: "Documents",
         value: formatter.number(nodeValue?.indices?.docs?.count || 0),
-        title: "Documents",
+        title: formatMessage({ id: "indices.field.docs_count" }),
       },
       {
         key: "Data",
         value: formatter.bytes(nodeValue?.indices?.store?.size_in_bytes || 0),
-        title: "Data",
+        title: formatMessage({ id: "overview.column.data" }),
       },
       {
         key: "JVM Heap",
@@ -104,7 +107,7 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
             : 0
           ).toFixed(2) +
           "%)",
-        title: "JVM Heap",
+        title: formatMessage({ id: "overview.column.jvm_heap" }),
       },
       {
         key: "Free Disk Space",
@@ -117,7 +120,7 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
             : 0
           ).toFixed(2) +
           "%)",
-        title: "Free Disk Space",
+        title: formatMessage({ id: "overview.column.disk_free_space" }),
       },
     ];
   }
@@ -126,10 +129,14 @@ const StatisticBar = ({ clusterID, nodeID, timeRange, setSpinning }) => {
       {!isAvailable ? (
         <div className={"mask"}>
           <div>
-            Node is not availabe since:{" "}
-            {nodeValue?.timestamp
-              ? formatUtcTimeToLocal(nodeValue?.timestamp)
-              : "N/A"}
+            {formatMessage(
+              { id: "overview.status.node_since" },
+              {
+                timestamp: nodeValue?.timestamp
+                  ? formatUtcTimeToLocal(nodeValue?.timestamp)
+                  : "N/A",
+              }
+            )}
           </div>
         </div>
       ) : null}

--- a/web/src/pages/Platform/Overview/Node/Table/index.jsx
+++ b/web/src/pages/Platform/Overview/Node/Table/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { Tooltip, Progress, Icon, Spin } from "antd";
 import { formatter } from "@/utils/format";
+import { formatMessage } from "umi/locale";
 import { HealthStatusView } from "@/components/infini/health_status_view";
 import { StatusBlockGroup } from "@/components/infini/status_block";
 import CommonTable from "../../components/CommonTable";
@@ -11,7 +12,7 @@ export default (props) => {
       {...props}
       columns={[
         {
-          title: "Name",
+          title: formatMessage({ id: "overview.column.name" }),
           dataIndex: "name",
           render: (text, record) => {
             return (
@@ -51,7 +52,7 @@ export default (props) => {
           },
         },
         {
-          title: "Status",
+          title: formatMessage({ id: "overview.column.status" }),
           dataIndex: "status",
           render: (text, record) => {
             return (
@@ -85,21 +86,21 @@ export default (props) => {
           },
         },
         {
-          title: "Indices",
+          title: formatMessage({ id: "overview.column.indices" }),
           dataIndex: "Indices",
           render: (text, record) => {
             return record.summary?.shard_info?.indices_count || 0;
           },
         },
         {
-          title: "Shards",
+          title: formatMessage({ id: "overview.column.shards" }),
           dataIndex: "Shards",
           render: (text, record) => {
             return record.summary?.shard_info?.shard_count || 0;
           },
         },
         {
-          title: "Docs",
+          title: formatMessage({ id: "overview.column.docs" }),
           dataIndex: "Docs",
           render: (text, record) => {
             return (
@@ -114,7 +115,7 @@ export default (props) => {
           },
         },
         {
-          title: "Disk Usage",
+          title: formatMessage({ id: "overview.column.disk_usage" }),
           dataIndex: "DiskUsage",
           render: (text, record) => {
             return (
@@ -141,7 +142,7 @@ export default (props) => {
           },
         },
         {
-          title: "JVM Heap",
+          title: formatMessage({ id: "overview.column.jvm_heap" }),
           dataIndex: "JVMHeap",
           render: (text, record) => {
             return (

--- a/web/src/pages/Platform/Overview/Node/index.tsx
+++ b/web/src/pages/Platform/Overview/Node/index.tsx
@@ -28,9 +28,24 @@ const aggsParams = [
 ];
 
 const details = [
-  { title: "Metrics", component: Metrics, key: "metrics" },
-  { title: "Infos", component: Infos, key: "infos" },
-  { title: "Logs", component: Logs, key: "logs" },
+  {
+    title: "Metrics",
+    titleId: "overview.detail.metrics",
+    component: Metrics,
+    key: "metrics",
+  },
+  {
+    title: "Infos",
+    titleId: "overview.detail.infos",
+    component: Infos,
+    key: "infos",
+  },
+  {
+    title: "Logs",
+    titleId: "cluster.monitor.tabs.logs",
+    component: Logs,
+    key: "logs",
+  },
 ];
 
 const sideSorterOptions = [

--- a/web/src/pages/Platform/Overview/components/CommonTable/index.jsx
+++ b/web/src/pages/Platform/Overview/components/CommonTable/index.jsx
@@ -71,6 +71,7 @@ export default (props) => {
         loading={loading}
         columns={columns}
         dataSource={tableData}
+        scroll={{ x: "max-content" }}
         rowKey={"id"}
         pagination={{
           size: "small",

--- a/web/src/pages/Platform/Overview/components/Logs/index.jsx
+++ b/web/src/pages/Platform/Overview/components/Logs/index.jsx
@@ -271,7 +271,7 @@ export default (props) => {
                                         onSearch={value => {
                                             setQueryParams((st) => ({ ...st, from: 0, keyword: value }));
                                         }} 
-                                        enterButton
+                                        enterButton={formatMessage({ id: "form.button.search" })}
                                     />
                                 </div>
                                 <div className={styles.histogram}>

--- a/web/src/pages/Platform/Overview/components/MetricChart.jsx
+++ b/web/src/pages/Platform/Overview/components/MetricChart.jsx
@@ -164,10 +164,10 @@ export default (props) => {
         const emptyProps = {}
         if (metric?.min_bucket_size > 0 && metric?.hits_total > 0) {
           emptyProps.description = (
-            <>
-              <div style={{ wordBreak: 'break-all', textAlign: 'left', marginBotton: 2 }} >
+            <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 6, width: '100%' }}>
+              <span style={{ wordBreak: 'break-all' }}>
                 {formatMessage({ id: "cluster.metrics.time_interval.empty" }, { min_bucket_size: metric.min_bucket_size})}
-              </div>
+              </span>
               <Dropdown overlay={(
                 <Menu>
                   <Menu.Item onClick={() => handleTimeIntervalChange(`${metric?.min_bucket_size}s`)}>
@@ -178,11 +178,11 @@ export default (props) => {
                   </Menu.Item>
                 </Menu>
               )}>
-                <a onClick={e => e.preventDefault()}>
+                <a style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }} onClick={e => e.preventDefault()}>
                   {formatMessage({ id: `cluster.metrics.time_interval.apply`})} <Icon type="down" />
                 </a>
               </Dropdown>
-            </>
+            </span>
           )
         }
         return (
@@ -322,20 +322,27 @@ export default (props) => {
     }
   
     return (
-      <div key={metricKey} ref={containerRef} className={className} style={style}>
+      <div
+        key={metricKey}
+        ref={containerRef}
+        className={[styles.metricChartContainer, className].filter(Boolean).join(" ")}
+        style={style}
+      >
         {
-                metric?.request && (
-                  <CopyToClipboard text={`GET .infini_metrics/_search\n${metric.request}`}>
-                    <Tooltip title={formatMessage({id: "cluster.metrics.request.copy"})}>
-                      <Icon 
-                        className="copyReq"
-                        type="copy" 
-                        onClick={() => message.success(formatMessage({id: "cluster.metrics.request.copy.success"}))}
-                      />
-                    </Tooltip>
-                  </CopyToClipboard>
-                )
-              }
+          metric?.request && (
+            <div className={styles.copyAction}>
+              <CopyToClipboard text={`GET .infini_metrics/_search\n${metric.request}`}>
+                <Tooltip title={formatMessage({id: "cluster.metrics.request.copy"})}>
+                  <Icon
+                    className={styles.copyReq}
+                    type="copy"
+                    onClick={() => message.success(formatMessage({id: "cluster.metrics.request.copy.success"}))}
+                  />
+                </Tooltip>
+              </CopyToClipboard>
+            </div>
+          )
+        }
         <Spin spinning={loading}>
         <div className={styles.vizChartItemTitle}>
           <span>

--- a/web/src/pages/Platform/Overview/components/Metrics.scss
+++ b/web/src/pages/Platform/Overview/components/Metrics.scss
@@ -25,26 +25,78 @@
   }
 }
 
-.vizChartContainer, .metric-item{
+.metricChartContainer {
   position: relative;
+  .copyAction {
+    position: absolute;
+    right: 12px;
+    bottom: 12px;
+    z-index: 11;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+  }
   .copyReq {
     cursor: pointer;
-    position: absolute;
-    display: none;
-    right: 3px;
-    bottom: 0px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 24px;
     height: 24px;
+    border-radius: 4px;
+    box-shadow: rgba(0, 0, 0, 0.16) 0px 0px 5px 0px;
+    background: #fff;
     z-index: 11;
     &:hover {
       color: #1890ff;
+      box-shadow: rgba(0, 0, 0, 0.3) 0px 0px 5px 0px;
     }
   }
   &:hover {
-    .copyReq {
-        display: block;
+    .copyAction {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
     }
+  }
 }
+
+.vizChartContainer, .metric-item{
+  position: relative;
+  .copyAction {
+    position: absolute;
+    right: 12px;
+    bottom: 12px;
+    z-index: 11;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+  }
+  .copyReq {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    box-shadow: rgba(0, 0, 0, 0.16) 0px 0px 5px 0px;
+    background: #fff;
+    z-index: 11;
+    &:hover {
+      color: #1890ff;
+      box-shadow: rgba(0, 0, 0, 0.3) 0px 0px 5px 0px;
+    }
+  }
+  &:hover {
+    .copyAction {
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+    }
+  }
 }
 
 .vizChartItem {
@@ -114,4 +166,3 @@
     flex: 1;
   }
 }
-

--- a/web/src/pages/Platform/Overview/components/TopN/index.jsx
+++ b/web/src/pages/Platform/Overview/components/TopN/index.jsx
@@ -594,13 +594,15 @@ export default (props) => {
             <div className={styles.content}>
                 {
                     result?.request && (
-                        <CopyToClipboard text={`GET .infini_metrics/_search\n${result.request}`}>
-                            <Tooltip title={formatMessage({id: "cluster.metrics.request.copy"})}>
-                                <div className={styles.info} onClick={() => message.success(formatMessage({id: "cluster.metrics.request.copy.success"}))}>
-                                    <Icon type="copy" />
-                                </div>
-                            </Tooltip>
-                        </CopyToClipboard>
+                        <div className={styles.copyAction}>
+                            <CopyToClipboard text={`GET .infini_metrics/_search\n${result.request}`}>
+                                <Tooltip title={formatMessage({id: "cluster.metrics.request.copy"})}>
+                                    <div className={styles.info} onClick={() => message.success(formatMessage({id: "cluster.metrics.request.copy.success"}))}>
+                                        <Icon type="copy" />
+                                    </div>
+                                </Tooltip>
+                            </CopyToClipboard>
+                        </div>
                     )
                 }
                 { isTreemap ? <Chart config={config} data={formatData} /> : <Table type={type} config={config} data={formatData}/> }

--- a/web/src/pages/Platform/Overview/components/TopN/index.less
+++ b/web/src/pages/Platform/Overview/components/TopN/index.less
@@ -49,21 +49,29 @@
     height: calc(100vh - 500px);
     min-height: 500px;
     position: relative;
+    overflow: hidden;
+
+    .copyAction {
+      position: absolute;
+      right: 12px;
+      bottom: 12px;
+      z-index: 11;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 0.2s ease, visibility 0.2s ease;
+    }
     
     .info {
-        position: absolute;
-        display: none;
-        right: 2px;
-        top: 2px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         width: 24px;
         height: 24px;
         border-radius: 4px;
-        line-height: 24px;
-        text-align: center;
         font-size: 16px;
         box-shadow: rgba(0, 0, 0, 0.16) 0px 0px 5px 0px;
         background: #fff;
-        z-index: 11;
         cursor: pointer;
         color: rgba(0, 0, 0, 0.45);
         transition: all 0.3s ease;
@@ -75,8 +83,10 @@
     }
 
     &:hover {
-      .info {
-          display: block;
+      .copyAction {
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
       }
     }
   }

--- a/web/src/pages/Platform/Overview/index.js
+++ b/web/src/pages/Platform/Overview/index.js
@@ -20,7 +20,7 @@ const { TabPane } = Tabs;
 
 const panes = [
   {
-    title: "Clusters",
+    titleId: "overview.title.cluster",
     component: Cluster,
     key: "clusters",
     count: 0,
@@ -29,7 +29,7 @@ const panes = [
     },
   },
   {
-    title: "Nodes",
+    titleId: "overview.title.node",
     component: Node,
     key: "nodes",
     count: 0,
@@ -38,7 +38,7 @@ const panes = [
     },
   },
   {
-    title: "Indices",
+    titleId: "overview.title.index",
     component: Indices,
     key: "indices",
     count: 0,
@@ -47,7 +47,7 @@ const panes = [
     },
   },
   // {
-  //   title: "Hosts",
+  //   titleId: "overview.title.host",
   //   component: Host,
   //   key: "hosts",
   //   count: 0,
@@ -99,7 +99,7 @@ const NewOverview = (props) => {
               tab={
                 <>
                   <pane.icon />
-                  {`${pane.title}(${pane.count})`}
+                  {`${formatMessage({ id: pane.titleId })}(${pane.count})`}
                 </>
               }
               key={pane.key}


### PR DESCRIPTION
## Summary
- expand cluster and platform overview APIs for richer metrics and treemap displays
- refresh cluster overview pages with the new monitor panels and repository details
- improve platform overview tables, charts, and shard drill-down views

## Testing
- go test ./modules/elastic/api ./modules/elastic/api/v1
- NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' ./node_modules/.bin/umi build