### PR TITLE
docs: update release notes for split changes

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -9,16 +9,49 @@ Information about release notes of INFINI Console is provided here.
 
 ## Latest (In development)  
 ### ❌ Breaking changes  
+- breaking: sensitive frontend operations now require HTTPS transport plus replay protection. Console must either enable HTTPS directly or run behind an HTTPS reverse proxy before using login, setup initialization/validation, password changes, credential management, cluster registration, or email-server write/test APIs over the UI
+- breaking: Console now keeps a single active JWT per user. Logging in again or logging out invalidates previously issued tokens for that user
 ### 🚀 Features  
+- feat: add a real System Settings page with Rollup control, embedded email server management, and backend Rollup setting APIs
+- feat: add native challenge-response login at `/account/login/challenge`, with password verifier/salt support for new, reset, updated, and upgraded native accounts
+- feat: add Console-only cluster `probe_path` support for WAF-restricted endpoints, stored in cluster labels and reused in version detection / registration flows
+- feat: add setup-wizard support for configurable primary shards, auto replicas, and conditional Easysearch rollup initialization
 ### 🐛 Bug fix  
+- fix: sanitize `/_info`, instance proxy, and instance try-connect responses so sensitive runtime fields are no longer exposed
+- fix: make logout invalidate the current JWT server-side and reject stale or replaced Bearer tokens during validation
+- fix: protect previously exposed insight visualization/dashboard/widget/map-label routes with login and permission guards
+- fix: avoid setup-mode startup failures by skipping task-manager scheduler/dispatcher work when setup is required
+- fix: allow alert email channels without a stored `server_id` to inherit the single enabled SMTP server automatically, so existing rules keep working after SMTP is configured
+- fix: block enabling incomplete email alert channels until an SMTP server and recipients are configured, and surface clearer channel-list hints instead of silently failing later
+- fix: harden Dev Tools, Search Flow, and related admin pages against missing cluster state, malformed aggregations, and inconsistent prompt copy
+- fix: normalize cluster connection-test failures into localized, user-friendly messages instead of raw `EOF`, HTML parse errors, or backend JSON reasons
+- fix: prevent missing `menu` locale warnings, unnamed-route React Intl title crashes, repeated logout 401 loops, and HealthProvider updates after unmount from breaking the main UI
+- fix: update Easysearch retention changes by recreating ILM policies with `policy.phases`, deleting stale target policies before recreation, and rebinding templates plus managed indices to the new policy
+- fix: keep Alerting rule list statuses neutral until rule health info finishes loading, instead of briefly showing an incorrect abnormal state first
+- fix: localize the platform role form labels and validation messages, and remove raw `/role/platform` path segments from its breadcrumb trail
+- fix: tighten native security, credential, and index-management admin APIs to match the updated frontend behavior
+- fix: prevent the shared cluster overview table area from forcing page-level horizontal scrolling when the filter sidebar is open
+- fix: avoid redundant hash-history updates in the shared overview URL sync so cluster overview no longer warns when pushing the same path
+- fix: ensure ListView header action fragments always receive unique React keys to remove duplicate-key warnings
 ### ✈️ Improvements  
-
-## 1.30.2 (2026-03-16)
-### ❌ Breaking changes  
-### 🚀 Features  
-### 🐛 Bug fix  
-### ✈️ Improvements  
-- This release includes updates from the underlying [Framework v1.4.0](https://docs.infinilabs.com/framework/v1.4.0), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Console itself, the improvements inherited from Framework benefit Console indirectly.
+- improve: surface red-cluster, auth-required, TLS-mismatch, non-Elasticsearch, unreachable-endpoint, and unexpected-status failures through stable localized error keys
+- improve: hide cluster `probe_path` behind an Advanced toggle by default while still honoring saved custom paths
+- improve: redirect the login page to the initialization guide when `setup_required=true` and keep setup flows resilient after local data/log resets
+- improve: update setup templates so ILM and rollup indices inherit configured shard and auto-replica defaults, including rollup target indices
+- improve: honor `/setting/application` capability flags when rendering plugin-backed menus, routes, shortcuts, and permission entries
+- improve: rename English system menus to `SYSTEM` / `SYSTEM SETTINGS` and show `System Settings` instead of `SMTP SERVER` in the role permission tree
+- improve: dedupe repeated `/setting/application` fetches, auto-reload once on stale chunk errors, disable cache for `manifest.json`, and streamline web builds with `run-umi.js`
+- improve: replace framework SMTP dependency in generated email pipelines with the Console-local `console_smtp` processor and enforce `cnpm`/`npminstall` for web installs
+- improve: show the browser-console startup banner with local-time build timestamps and upgrade Dev Tools editor defaults to a more readable font stack and larger default size
+- improve: suppress noisy `umi.dll.js` warning output outside development while still keeping warnings visible during local dev
+- improve: reduce background `/elasticsearch/status` polling by refreshing only while the page is visible, adding client-side TTL caching, and reserving force refresh for explicit actions
+- improve: expose system-managed ILM rollover size in System Settings and allow retention updates to carry both delete age and rollover storage threshold
+- improve: dedupe bursty frontend error toasts and cap concurrent global message bubbles so repeated failures no longer flood the screen
+- improve: align cluster overview layout with the rest of the console by moving facet filters to a left sidebar
+- improve: align cluster overview with cluster activities by using a dedicated left filter sidebar and moving sidebar collapse toggles to the top for easier access
+- improve: shrink the product updates card on the overview page to its content height so short update lists no longer leave large blank areas
+- improve: align the cluster activities panel on the overview page to the height of the left column so both sides end cleanly without mismatched bottoms
+- improve: collapse left-side filters by default in platform overview, cluster activities, and audit logs to leave more room for data
 
 ## 1.30.1 (2025-12-19)
 ### ❌ Breaking changes  

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -9,16 +9,50 @@ title: "版本历史"
 
 ## Latest (In development)  
 ### ❌ Breaking changes  
+- breaking: 前端敏感操作现在必须同时满足 HTTPS 传输与重放保护。要继续在 UI 中执行登录、初始化校验/执行、密码修改、凭据管理、集群注册以及邮件服务器写入/测试等操作，必须直接开启 Console HTTPS，或将 Console 部署在 HTTPS 反向代理之后
+- breaking: Console 现在对每个用户只保留一个有效 JWT。重新登录或退出登录后，该用户此前签发的旧令牌会立即失效
 ### 🚀 Features  
+- feat: 新增真正可用的“系统设置”页面，集成 Rollup 开关、嵌入式邮件服务器管理，以及对应的后端 Rollup 设置接口
+- feat: 为 `/account/login/challenge` 增加原生挑战应答登录，并为新建、重置、修改及升级后的本地账号写入密码 verifier/salt
+- feat: 为受 WAF 限制的集群增加 Console 侧 `probe_path` 能力，将其保存到集群标签中并在注册/版本探测流程中复用
+- feat: 为初始化向导增加主分片数、自动副本和 Easysearch Rollup 条件初始化支持
 ### 🐛 Bug fix  
-### ✈️ Improvements  
+- fix: 清洗 `/_info`、实例代理和实例连通性测试响应，避免继续暴露敏感运行时字段
+- fix: 修复退出登录后 JWT 仍可继续访问的问题，服务端现在会失效当前令牌并拒绝旧/被替换的 Bearer Token
+- fix: 为此前暴露的 insight visualization/dashboard/widget/map-label 路由补齐登录与权限保护
+- fix: 在需要初始化时跳过 task-manager 的 scheduler/dispatcher 启动逻辑，避免 setup 模式下启动失败
+- fix: 修复旧邮件告警通道缺少 `server_id` 时无法发送的问题；当系统中仅启用一个 SMTP 服务器时，现会自动继承该服务器
+- fix: 修复邮件告警渠道未完成 SMTP/收件人配置时也能被启用的问题；现在会在渠道列表直接提示并阻止启用，避免后续执行时才失败
+- fix: 增强 Dev Tools、Search Flow 以及相关管理页面对空集群状态、异常聚合结果和不一致提示文案的容错
+- fix: 将集群连通性测试错误统一为本地化、可读的提示，不再直接暴露 `EOF`、HTML 解析错误或后端原始 JSON reason
+- fix: 修复 `menu` 语言项缺失告警、无名路由 React Intl 标题崩溃、登出 401 循环，以及 HealthProvider 组件卸载后仍更新状态导致的主界面异常
+- fix: 修复 Easysearch 数据保留期更新流程：改为按 `policy.phases` 重新创建 ILM policy，在重建前删除同名旧策略，并将模板与受管索引重新绑定到新的保留期策略
+- fix: 修复告警规则列表状态在规则健康信息尚未返回前先短暂显示为异常的问题，改为先保持中性占位再展示真实红绿状态
+- fix: 平台角色表单页补齐标签与校验文案国际化，并移除面包屑中原样显示的 `/role/platform` 路径段
+- fix: 收紧本地安全、凭据和索引管理相关后台接口行为，使其与更新后的前端管理流程保持一致
+- fix: 修复共享 Overview URL 状态同步的重复写入，避免集群总览在推送相同路径时触发 hash-history 告警
+- fix: 修复 ListView 头部操作区 Fragment key 可能重复的问题，消除重复 key 告警
+- fix: 修复集群总览共享表格区域在左侧过滤栏展开时把页面撑出横向滚动条的问题
 
-## 1.30.2 (2026-03-16)
-### ❌ Breaking changes  
-### 🚀 Features  
-### 🐛 Bug fix  
 ### ✈️ Improvements  
-- 此版本包含了底层 [Framework v1.4.0](https://docs.infinilabs.com/framework/v1.4.0) 的更新，解决了一些常见问题，并增强了整体稳定性和性能。虽然 Console 本身没有直接的变更，但从 Framework 中继承的改进间接地使 Console 受益。
+- improve: 通过稳定的本地化错误 key 展示红集群、鉴权失败、TLS 协议不匹配、非 Elasticsearch 端点、端点不可达和异常状态码等错误
+- improve: 默认将集群 `probe_path` 隐藏到“高级设置”中，同时继续兼容已保存的自定义路径
+- improve: 当 `setup_required=true` 时，登录页会自动跳转到初始化向导，并提升清空本地 data/log 后的 setup 流程韧性
+- improve: 更新 setup 模板，让 ILM 和 Rollup 相关索引继承配置的分片数与自动副本策略，包括 rollup 目标索引
+- improve: 在渲染插件侧菜单、路由、首页快捷入口和权限项时，统一遵循 `/setting/application` 返回的能力开关
+- improve: 将英文系统菜单改为 `SYSTEM` / `SYSTEM SETTINGS`，并在角色权限树中把 `SMTP SERVER` 展示为 `System Settings`
+- improve: 合并重复的 `/setting/application` 请求，增加 stale chunk 自动刷新、`manifest.json` 禁缓存处理，并通过 `run-umi.js` 优化前端构建
+- improve: 用 Console 本地 `console_smtp` 处理器替代生成邮件 pipeline 对 framework SMTP 的依赖，并为 web 安装流程增加 `cnpm` / `npminstall` 限制
+- improve: 浏览器控制台启动欢迎信息改为显示本地时区构建时间，并为 Dev Tools 编辑器切换到更易读的字体栈和更大的默认字号
+- improve: 在非开发环境下屏蔽 `umi.dll.js` 带来的噪声告警输出，同时保留开发模式下的原始告警
+- improve: 优化 `/elasticsearch/status` 的后台轮询策略，仅在页面可见时刷新，增加前端 TTL 缓存，并将强制刷新保留给显式用户操作
+- improve: 在系统设置页展示系统托管 ILM 的 rollover 存储大小，并让保留期更新同时携带删除天数与 rollover 存储阈值
+- improve: 优化前端错误提示泡泡：对短时间内重复错误做去重，并限制全局 message 同时显示数量，避免失败时满屏重复弹泡
+- improve: 调整集群总览页布局，将筛选条件统一移到左侧栏，和控制台其他页面保持一致
+- improve: 对齐集群总览与集群活动页布局：统一使用独立左侧过滤栏，并将侧栏折叠入口移动到顶部，减少操作成本
+- improve: 优化概览页“产品动态”卡片高度：当动态条目较少时按内容自适应收起，避免出现大块空白
+- improve: 优化概览页“集群动态”面板高度：右侧根据左侧内容高度对齐，避免左右两列底部不齐
+- improve: 平台概览、集群动态与审计日志页默认收起左侧过滤栏，为数据内容释放更多空间
 
 ## 1.30.1 (2025-12-19)
 ### ❌ Breaking changes  


### PR DESCRIPTION
## Summary
- refresh the in-development release notes to match the split Console PRs that remain in scope
- remove DataTools-only and other unsubmitted items from the latest release notes section
- keep the English and Chinese release notes aligned for the surviving changes

## Testing
- not applicable (docs only)