### PR TITLE
improve: polish data management pages

### DIFF
--- a/web/src/components/vendor/data/public/ui/filter_bar/filter_editor/lib/filter_label.tsx
+++ b/web/src/components/vendor/data/public/ui/filter_bar/filter_editor/lib/filter_label.tsx
@@ -49,7 +49,7 @@ export default function FilterLabel({ filter, valueLabel, filterLabelStatus }: F
 
   if (filter.meta.alias !== null) {
     return (
-      <Fragment>
+      <Fragment key={filter.meta.alias}>
         {prefix}
         {filter.meta.alias}
         {filterLabelStatus && <>: {getValue(valueLabel)}</>}
@@ -60,35 +60,35 @@ export default function FilterLabel({ filter, valueLabel, filterLabelStatus }: F
   switch (filter.meta.type) {
     case FILTERS.EXISTS:
       return (
-        <Fragment>
+        <Fragment key={filter.meta.key}>
           {prefix}
           {filter.meta.key}: {getValue(`${existsOperator.message}`)}
         </Fragment>
       );
     case FILTERS.GEO_BOUNDING_BOX:
       return (
-        <Fragment>
+        <Fragment key={filter.meta.key}>
           {prefix}
           {filter.meta.key}: {getValue(valueLabel)}
         </Fragment>
       );
     case FILTERS.GEO_POLYGON:
       return (
-        <Fragment>
+        <Fragment key={filter.meta.key}>
           {prefix}
           {filter.meta.key}: {getValue(valueLabel)}
         </Fragment>
       );
     case FILTERS.PHRASES:
       return (
-        <Fragment>
+        <Fragment key={filter.meta.key}>
           {prefix}
           {filter.meta.key}: {getValue(`${isOneOfOperator.message} ${valueLabel}`)}
         </Fragment>
       );
     case FILTERS.QUERY_STRING:
       return (
-        <Fragment>
+        <Fragment key={filter.meta.key}>
           {prefix}
           {getValue(`${valueLabel}`)}
         </Fragment>
@@ -96,14 +96,14 @@ export default function FilterLabel({ filter, valueLabel, filterLabelStatus }: F
     case FILTERS.PHRASE:
     case FILTERS.RANGE:
       return (
-        <Fragment>
+        <Fragment key={filter.meta.key}>
           {prefix}
           {filter.meta.key}: {getValue(valueLabel)}
         </Fragment>
       );
     default:
       return (
-        <Fragment>
+        <Fragment key={filter.meta.key}>
           {prefix}
           {getValue(`${JSON.stringify(filter.query) || filter.meta.value}`)}
         </Fragment>

--- a/web/src/components/vendor/data/public/ui/query_string_input/query_bar_top_row.tsx
+++ b/web/src/components/vendor/data/public/ui/query_string_input/query_bar_top_row.tsx
@@ -30,7 +30,7 @@ import {
   prettyDuration,
 } from "@elastic/eui";
 // @ts-ignore
-import { EuiSuperUpdateButton, OnRefreshProps } from "@elastic/eui";
+import { OnRefreshProps } from "@elastic/eui";
 import { Toast } from "src/core/public";
 import { IIndexPattern, TimeRange, TimeHistoryContract, Query } from "../..";
 import { toMountPoint, withKibana } from "../../../../react/public";
@@ -40,7 +40,7 @@ import { NoDataPopover } from "./no_data_popover";
 import { DiscoverHistogram } from "@/components/vendor/discover/public/application/components/histogram/histogram";
 import DatePicker from "@/common/src/DatePicker";
 import styles from "./query_bar_top_row.less";
-import { getLocale } from "umi/locale";
+import { formatMessage, getLocale } from "umi/locale";
 
 const QueryStringInput = withKibana(QueryStringInputUI);
 
@@ -251,14 +251,25 @@ export default function QueryBarTopRow(props: QueryBarTopRowProps) {
         className: styles.euiButtonRefresh,
       })
     ) : (
-      <EuiSuperUpdateButton
-        needsUpdate={props.isDirty}
+      <EuiButton
+        fill
+        color={props.isDirty || props.isLoading ? "secondary" : "primary"}
+        iconType={props.isDirty || props.isLoading ? "kqlFunction" : "refresh"}
+        textProps={{
+          className: "euiSuperUpdateButton__text",
+        }}
         isDisabled={isDateRangeInvalid}
         isLoading={props.isLoading}
         onClick={onClickSubmitButton}
         data-test-subj="querySubmitButton"
-        className={styles.euiButtonRefresh}
-      />
+        className={classNames("euiSuperUpdateButton", styles.euiButtonRefresh)}
+      >
+        {props.isLoading
+          ? formatMessage({ id: "insight.button.updating" })
+          : props.isDirty
+          ? formatMessage({ id: "form.button.update" })
+          : formatMessage({ id: "form.button.refresh" })}
+      </EuiButton>
     );
 
     return (

--- a/web/src/components/vendor/data/public/ui/saved_query_management/saved_query_list_item.tsx
+++ b/web/src/components/vendor/data/public/ui/saved_query_management/saved_query_list_item.tsx
@@ -67,7 +67,7 @@ export const SavedQueryListItem = ({
   );
 
   return (
-    <Fragment>
+    <Fragment key={savedQuery.id}>
       <EuiListGroupItem
         className={classes}
         key={savedQuery.id}

--- a/web/src/components/vendor/data/public/ui/saved_query_management/saved_query_management_component.tsx
+++ b/web/src/components/vendor/data/public/ui/saved_query_management/saved_query_management_component.tsx
@@ -179,7 +179,7 @@ export function SavedQueryManagementComponent({
   };
 
   return (
-    <Fragment>
+    <Fragment key="savedQueryManagement">
       <EuiPopover
         id="savedQueryPopover"
         button={savedQueryPopoverButton}
@@ -199,7 +199,7 @@ export function SavedQueryManagementComponent({
             {savedQueryPopoverTitleText}
           </EuiPopoverTitle>
           {savedQueries.length > 0 ? (
-            <Fragment>
+            <Fragment key="savedQueryList">
               <EuiText size="s" color="subdued" className="kbnSavedQueryManagement__text">
                 <p>{savedQueryDescriptionText}</p>
               </EuiText>
@@ -220,7 +220,7 @@ export function SavedQueryManagementComponent({
               />
             </Fragment>
           ) : (
-            <Fragment>
+            <Fragment key="noSavedQueries">
               <EuiText size="s" color="subdued" className="kbnSavedQueryManagement__text">
                 <p>{noSavedQueriesDescriptionText}</p>
               </EuiText>
@@ -237,7 +237,7 @@ export function SavedQueryManagementComponent({
               wrap={true}
             >
               {showSaveQuery && loadedSavedQuery && (
-                <Fragment>
+                <Fragment key="saveQueryActions">
                   <EuiFlexItem grow={false}>
                     <EuiButton
                       size="s"

--- a/web/src/components/vendor/discover/public/application/angular/directives/no_results.js
+++ b/web/src/components/vendor/discover/public/application/angular/directives/no_results.js
@@ -51,7 +51,7 @@ export class DiscoverNoResults extends Component {
 
     if (timeFieldName) {
       timeFieldMessage = (
-        <Fragment>
+        <Fragment key="timeFieldMessage">
           <EuiSpacer size="xl" />
 
           <EuiText>
@@ -73,7 +73,11 @@ export class DiscoverNoResults extends Component {
                   id: "explore.no_results.timerange.tips",
                 })}
               </a>
-              <Spin spinning={timeTipsLoading} indicator={antIcon}/>
+              {timeTipsLoading ? (
+                <span style={{ display: "inline-flex", marginLeft: 8 }}>
+                  {antIcon}
+                </span>
+              ) : null}
             </p>
           </EuiText>
         </Fragment>
@@ -135,7 +139,7 @@ export class DiscoverNoResults extends Component {
       ];
 
       luceneQueryMessage = (
-        <Fragment>
+        <Fragment key="luceneQueryMessage">
           <EuiSpacer size="xl" />
 
           <EuiText>
@@ -162,7 +166,7 @@ export class DiscoverNoResults extends Component {
     }
 
     return (
-      <Fragment>
+      <Fragment key="discoverNoResults">
         <EuiSpacer size="xl" />
 
         <EuiFlexGroup justifyContent="center">

--- a/web/src/components/vendor/discover/public/application/components/discover_table/table.tsx
+++ b/web/src/components/vendor/discover/public/application/components/discover_table/table.tsx
@@ -95,7 +95,7 @@ const Table: React.FC<TableProps> = ({
                   {hits.map((row, idx) => {
                     return (
                       <TableRow
-                        key={"discover-table-row" + row._id}
+                        key={`discover-table-row-${row._index || "unknown"}-${row._id || "unknown"}-${idx}`}
                         onFilter={onFilter}
                         columns={columns}
                         hideTimeColumn={false}

--- a/web/src/components/vendor/index_pattern_management/public/components/create_button/create_button.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/create_button/create_button.tsx
@@ -106,7 +106,7 @@ export class CreateButton extends Component<Props, State> {
                   <EuiDescriptionList style={{ whiteSpace: 'nowrap' }}>
                     <EuiDescriptionListTitle>
                       {option.text}
-                      {option.isBeta ? <Fragment> {this.renderBetaBadge()}</Fragment> : null}
+                      {option.isBeta ? <Fragment key={`${option.text}-beta`}> {this.renderBetaBadge()}</Fragment> : null}
                     </EuiDescriptionListTitle>
                     <EuiDescriptionListDescription>
                       {option.description}

--- a/web/src/components/vendor/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -56,8 +56,8 @@ const confirmMessage =
   "This action resets the popularity counter of each field.";
 
 const confirmModalOptionsRefresh = {
-  confirmButtonText: "Refresh",
-  title: "Refresh field list?",
+  confirmButtonText: formatMessage({ id: "form.button.refresh" }),
+  title: formatMessage({ id: "explore.view.index_pattern.refreshFieldListTitle" }),
 };
 
 const confirmModalOptionsDelete = {

--- a/web/src/components/vendor/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -41,9 +41,13 @@ const setDefaultAriaLabel = "设置为默认视图";
 
 const setDefaultTooltip = "设置为默认视图";
 
-const refreshAriaLabel = "重新加载字段列表";
+const refreshAriaLabel = formatMessage({
+  id: "explore.view.index_pattern.refreshTooltip",
+});
 
-const refreshTooltip = "刷新字段列表";
+const refreshTooltip = formatMessage({
+  id: "explore.view.index_pattern.refreshTooltip",
+});
 
 const removeAriaLabel = formatMessage({
   id: "explore.view.index_pattern.removeTooltip",

--- a/web/src/components/vendor/index_pattern_management/public/components/edit_index_pattern/tabs/tabs.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/edit_index_pattern/tabs/tabs.tsx
@@ -235,7 +235,7 @@ export function Tabs({
       switch (type) {
         case TAB_INDEXED_FIELDS:
           return (
-            <Fragment>
+            <Fragment key={type}>
               <EuiSpacer size="m" />
               {getFilterSection(type)}
               <EuiSpacer size="m" />
@@ -256,7 +256,7 @@ export function Tabs({
           );
         case TAB_COMPLEX_FIELDS:
             return (
-              <Fragment>
+              <Fragment key={type}>
                 <EuiSpacer size="m" />
                 {getComplexFilterSection()}
                 <EuiSpacer size="m" />
@@ -275,7 +275,7 @@ export function Tabs({
             );
         case TAB_SCRIPTED_FIELDS:
           return (
-            <Fragment>
+            <Fragment key={type}>
               <EuiSpacer size="m" />
               {getFilterSection(type)}
               <EuiSpacer size="m" />
@@ -296,7 +296,7 @@ export function Tabs({
           );
         case TAB_SOURCE_FILTERS:
           return (
-            <Fragment>
+            <Fragment key={type}>
               <EuiSpacer size="m" />
               {getFilterSection(type)}
               <EuiSpacer size="m" />

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/complex_field_editor.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/complex_field_editor.tsx
@@ -254,7 +254,7 @@ export class ComplexFieldEditor extends PureComponent<FieldEdiorProps, FieldEdit
     );
 
     return (
-      <Fragment>
+      <Fragment key="formatSection">
         <EuiFormRow
           label={label}
           helpText={

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/color.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/color.tsx
@@ -210,7 +210,7 @@ export class ColorFormatEditor extends DefaultFormatEditor<
     ];
 
     return (
-      <Fragment>
+      <Fragment key="colorFormatEditor">
         <EuiBasicTable items={items} columns={columns} />
         <EuiSpacer size="m" />
         <EuiButton iconType="plusInCircle" size="s" onClick={this.addColor}>

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/date.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/date.tsx
@@ -47,7 +47,7 @@ export class DateFormatEditor extends DefaultFormatEditor<DateFormatEditorFormat
     const defaultPattern = format.getParamDefaults().pattern;
 
     return (
-      <Fragment>
+      <Fragment key="dateFormatEditor">
         <EuiFormRow
           label={
             `Moment.js format pattern (Default: ${<EuiCode>{defaultPattern}</EuiCode>})`

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/date_nanos.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/date_nanos.tsx
@@ -46,7 +46,7 @@ export class DateNanosFormatEditor extends DefaultFormatEditor<DateNanosFormatEd
     const defaultPattern = format.getParamDefaults().pattern;
 
     return (
-      <Fragment>
+      <Fragment key="dateNanosFormatEditor">
         <EuiFormRow
           label={
             `Moment.js format pattern (Default: ${<EuiCode>{defaultPattern}</EuiCode>})`

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/duration.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/duration.tsx
@@ -94,7 +94,7 @@ export class DurationFormatEditor extends DefaultFormatEditor<
     const { error, samples, hasDecimalError } = this.state;
 
     return (
-      <Fragment>
+      <Fragment key="durationFormatEditor">
         <EuiFormRow
           label={
             "Input format"

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/number.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/number.tsx
@@ -42,7 +42,7 @@ export class NumberFormatEditor extends DefaultFormatEditor<NumberFormatEditorPa
     const defaultPattern = format.getParamDefaults().pattern;
 
     return (
-      <Fragment>
+      <Fragment key="numberFormatEditor">
         <EuiFormRow
           label={
             `Numeral.js format pattern (Default: ${<EuiCode>{defaultPattern}</EuiCode>})`

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/static_lookup.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/static_lookup.tsx
@@ -142,7 +142,7 @@ export class StaticLookupFormatEditor extends DefaultFormatEditor<
     ];
 
     return (
-      <Fragment>
+      <Fragment key="staticLookupFormatEditor">
         <EuiBasicTable items={items} columns={columns} style={{ maxWidth: '400px' }} />
         <EuiSpacer size="m" />
         <EuiButton iconType="plusInCircle" size="s" onClick={this.addLookup}>

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/string.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/string.tsx
@@ -53,7 +53,7 @@ export class StringFormatEditor extends DefaultFormatEditor<StringFormatEditorFo
     const { error, samples } = this.state;
 
     return (
-      <Fragment>
+      <Fragment key="stringFormatEditor">
         <EuiFormRow
           label={
             "Transform"

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/truncate.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/truncate.tsx
@@ -43,7 +43,7 @@ export class TruncateFormatEditor extends DefaultFormatEditor<TruncateFormatEdit
     const { error, samples } = this.state;
 
     return (
-      <Fragment>
+      <Fragment key="truncateFormatEditor">
         <EuiFormRow
           label={
             "Field length"

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url.tsx
@@ -141,7 +141,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
     const width = this.sanitizeNumericValue(this.props.formatParams.width);
     const height = this.sanitizeNumericValue(this.props.formatParams.height);
     return (
-      <Fragment>
+      <Fragment key="widthHeightParameters">
         <EuiFormRow
           label={
             "Width"
@@ -177,7 +177,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
     const { error, samples, sampleConverterType } = this.state;
 
     return (
-      <Fragment>
+      <Fragment key="urlFormatEditor">
         <LabelTemplateFlyout
           isVisible={this.state.showLabelTemplateHelp}
           onClose={this.hideLabelTemplateHelp}

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.tsx
@@ -24,7 +24,7 @@ import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 
 export const ScriptingDisabledCallOut = ({ isVisible = false }) => {
   return isVisible ? (
-    <Fragment>
+    <Fragment key="scriptingDisabledCallOut">
       <EuiCallOut
         title={
           "Scripting disabled"

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
@@ -34,7 +34,7 @@ export const ScriptingWarningCallOut = ({ isVisible = false }: ScriptingWarningC
   const docLinksScriptedFields = useGlobalContext().docLinks?.links//useKibana<IndexPatternManagmentContext>().services.docLinks?.links
     .scriptedFields;
   return isVisible ? (
-    <Fragment>
+    <Fragment key="scriptingWarningCallOut">
       <EuiCallOut
         title={
           "Proceed with caution"

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
@@ -28,7 +28,7 @@ export const ScriptingSyntax = () => {
   const docLinksScriptedFields =  useGlobalContext().docLinks?.links//useKibana<IndexPatternManagmentContext>().services.docLinks?.links
     .scriptedFields;
   return (
-    <Fragment>
+    <Fragment key="scriptingSyntax">
       <EuiSpacer />
       <EuiText>
         <h3>

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_help/test_script.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/components/scripting_help/test_script.tsx
@@ -161,7 +161,7 @@ export class TestScript extends Component<TestScriptProps, TestScriptState> {
     }
 
     return (
-      <Fragment>
+      <Fragment key="scriptPreview">
         <EuiTitle size="xs">
           <p>First 10 results</p>
         </EuiTitle>
@@ -213,7 +213,7 @@ export class TestScript extends Component<TestScriptProps, TestScriptState> {
     });
 
     return (
-      <Fragment>
+      <Fragment key="toolbar">
         <EuiFormRow label={"Additional fields"} fullWidth>
           <EuiComboBox
             placeholder={"Select..."}
@@ -253,7 +253,7 @@ export class TestScript extends Component<TestScriptProps, TestScriptState> {
 
   render() {
     return (
-      <Fragment>
+      <Fragment key="testScript">
         <EuiSpacer />
         <EuiText>
           <h3>Preview results</h3>

--- a/web/src/components/vendor/index_pattern_management/public/components/field_editor/field_editor.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/field_editor/field_editor.tsx
@@ -467,7 +467,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
     );
 
     return (
-      <Fragment>
+      <Fragment key="formatSection">
         <EuiFormRow
           label={label}
           helpText={
@@ -538,7 +538,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
     )
     
     return spec.scripted ? (
-      <Fragment>
+      <Fragment key="scriptSection">
         <EuiFormRow
           fullWidth
           label={'Script'}
@@ -556,7 +556,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         </EuiFormRow>
 
         <EuiFormRow>
-          <Fragment>
+          <Fragment key="scriptHelpSection">
             <EuiText>
               Access fields with  <code>{`doc['some_field'].value`}</code>.
             </EuiText>
@@ -673,7 +673,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
     }
 
     return (
-      <Fragment>
+      <Fragment key="scriptSection">
         <ScriptingDisabledCallOut isVisible={!scriptingLangs.length} />
         <ScriptingWarningCallOut isVisible />
         <ScriptingHelpFlyout

--- a/web/src/components/vendor/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/web/src/components/vendor/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -220,6 +220,7 @@ export const IndexPatternTable = ({
     },
     {
       title: formatMessage({ id: "table.field.actions" }),
+      width: 100,
       render: (text, record) => (
         <div>
           {canSave && !record.builtin ? (
@@ -294,8 +295,8 @@ export const IndexPatternTable = ({
           <div style={{ maxWidth: 500, flex: "1 1 auto" }}>
             <Search
               allowClear
-              placeholder="Type keyword to search"
-              enterButton="Search"
+              placeholder={formatMessage({ id: "listview.search.placeholder" })}
+              enterButton={formatMessage({ id: "form.button.search" })}
               onSearch={(value) => {
                 setSearchValue(value);
               }}

--- a/web/src/pages/DataManagement/Alias.js
+++ b/web/src/pages/DataManagement/Alias.js
@@ -156,6 +156,7 @@ class AliasManage extends PureComponent {
     },
     {
       title: formatMessage({ id: "alias.table.field.write_index" }),
+      with: 150,
       dataIndex: "write_index",
       sorter: (a, b) => sorter.string(a, b, "write_index"),
       render: (text, record) => {
@@ -164,14 +165,15 @@ class AliasManage extends PureComponent {
     },
     {
       title: formatMessage({ id: "table.field.actions" }),
+      width: 100,
       render: (text, record) => {
         return (
-          <Fragment>
+          <Fragment key={record.alias}>
             {/*<a onClick={() => this.handleUpdateModalVisible(true, record)}>别名设置</a>*/}
             {/*<Divider type="vertical" />*/}
             {hasAuthority("data.alias:all") ? (
               <Popconfirm
-                title="Sure to delete？"
+                title={formatMessage({ id: "app.message.confirm.delete" })}
                 onConfirm={() => this.handleDeleteAliasClick(record)}
               >
                 {" "}

--- a/web/src/pages/DataManagement/Discover.jsx
+++ b/web/src/pages/DataManagement/Discover.jsx
@@ -70,6 +70,7 @@ import {
   BooleanParam
 } from "use-query-params";
 import { Link, Route } from "umi";
+import { formatMessage } from "umi/locale";
 import { ESPrefix } from "@/services/common";
 import TraceChart from "./trace_chart";
 import TraceSearch from "./SearchFlow/TraceSearch";
@@ -87,6 +88,78 @@ import { getTimezone } from "@/utils/utils";
 import { hasAuthority } from "@/utils/authority";
 
 const SidebarMemoized = React.memo(DiscoverSidebar);
+const SHARE_STATE_VERSION = 1;
+
+const encodeShareState = (value) => {
+  try {
+    return btoa(unescape(encodeURIComponent(JSON.stringify(value))))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+  } catch (e) {
+    return "";
+  }
+};
+
+const decodeShareState = (value) => {
+  if (!value) {
+    return null;
+  }
+  try {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized + "=".repeat((4 - normalized.length % 4) % 4);
+    return JSON.parse(decodeURIComponent(escape(atob(padded))));
+  } catch (e) {
+    return null;
+  }
+};
+
+const updateHashQueryParams = (href, patch = {}) => {
+  try {
+    const url = new URL(href);
+    url.searchParams.delete("_reload_ts");
+    const hashValue = (url.hash || "#").slice(1);
+    const [hashPath, hashQuery = ""] = hashValue.split("?");
+    const params = new URLSearchParams(hashQuery);
+
+    Object.entries(patch).forEach(([key, value]) => {
+      params.delete(key);
+      if (
+        value === undefined ||
+        value === null ||
+        value === "" ||
+        (Array.isArray(value) && value.length === 0)
+      ) {
+        return;
+      }
+      if (Array.isArray(value)) {
+        value.forEach((item) => {
+          if (item !== undefined && item !== null && item !== "") {
+            params.append(key, String(item));
+          }
+        });
+        return;
+      }
+      params.set(key, String(value));
+    });
+
+    const nextQuery = params.toString();
+    url.hash = nextQuery ? `${hashPath}?${nextQuery}` : hashPath;
+    return url.toString();
+  } catch (e) {
+    return href;
+  }
+};
+
+const areArrayValuesEqual = (left = [], right = []) => {
+  if (left === right) {
+    return true;
+  }
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+    return false;
+  }
+  return left.every((item, index) => item === right[index]);
+};
 
 const {
   filterManager,
@@ -125,6 +198,7 @@ const Discover = (props) => {
   const [insightLoading, setInsightLoading] = useState(false);
   const [showResultCount, setShowResultCount] = useState(true);
   const [selectedQueries, setSelectedQueries] = useState();
+  const appliedShareRef = useRef("");
 
   const [columnsParam, setColumnsParam] = useQueryParam("columns", ArrayParam);
 
@@ -141,6 +215,7 @@ const Discover = (props) => {
     "sq",
     StringParam
   );
+  const [shareParam] = useQueryParam("share", StringParam);
   const [trackTotalHits, setTrackTotalHits] = useQueryParam(
     "tth",
     BooleanParam
@@ -257,12 +332,12 @@ const Discover = (props) => {
     IP.timeFieldName = timeField;
     props.changeIndexPattern(IP);
     const newSort = [[timeField, 'desc']]
-    setState({
-      ...state,
+    setState((st) => ({
+      ...st,
       columns: ["_source"],
       sort: newSort,
-    });
-    updateQuery({ sort: newSort });
+    }));
+    updateQuery({ indexPattern: IP, sort: newSort });
   };
 
   //const indexPatterns = [{"id":"1ccce5c0-bb9a-11eb-957b-939add21a246","type":"index-pattern","namespaces":["default"],"updated_at":"2021-05-23T07:40:14.747Z","version":"WzkxOTEsNDhd","attributes":{"title":"test-custom*","timeFieldName":"created_at","fields":"[{\"count\":0,\"name\":\"_id\",\"type\":\"string\",\"esTypes\":[\"_id\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_index\",\"type\":\"string\",\"esTypes\":[\"_index\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_score\",\"type\":\"number\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_source\",\"type\":\"_source\",\"esTypes\":[\"_source\"],\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_type\",\"type\":\"string\",\"esTypes\":[\"_type\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"address\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"address.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"subType\":{\"multi\":{\"parent\":\"address\"}}},{\"count\":0,\"conflictDescriptions\":{\"text\":[\"test-custom1\"],\"long\":[\"test-custom\",\"test-custom8\",\"test-custom9\"]},\"name\":\"age\",\"type\":\"conflict\",\"esTypes\":[\"text\",\"long\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"age.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"subType\":{\"multi\":{\"parent\":\"age\"}}},{\"count\":0,\"name\":\"created_at\",\"type\":\"date\",\"esTypes\":[\"date\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"email\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"email.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"subType\":{\"multi\":{\"parent\":\"email\"}}},{\"count\":0,\"name\":\"hobbies\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"hobbies.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"subType\":{\"multi\":{\"parent\":\"hobbies\"}}},{\"count\":0,\"name\":\"id\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"id.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"subType\":{\"multi\":{\"parent\":\"id\"}}},{\"count\":0,\"name\":\"name\",\"type\":\"string\",\"esTypes\":[\"text\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"name.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"subType\":{\"multi\":{\"parent\":\"name\"}}}]"},"references":[],"migrationVersion":{"index-pattern":"7.6.0"}}];
@@ -377,7 +452,10 @@ const Discover = (props) => {
       if (query != queryParam) {
         setQueryParam(query);
       }
-      setTimeParam([timefilter._time?.from, timefilter._time?.to]);
+      const nextTimeParam = [timefilter._time?.from, timefilter._time?.to];
+      if (!areArrayValuesEqual(timeParam || [], nextTimeParam)) {
+        setTimeParam(nextTimeParam);
+      }
 
       // let filters = filterManager.getFilters();
       // const tfilter = timefilter.createFilter(indexPattern);
@@ -580,8 +658,123 @@ const Discover = (props) => {
   //   });
   // };
   useEffect(() => {
-    setColumnsParam(state.columns);
-  }, [state.columns]);
+    if (!areArrayValuesEqual(columnsParam || [], state.columns || [])) {
+      setColumnsParam(state.columns);
+    }
+  }, [columnsParam, state.columns]);
+
+  const getShareUrl = useCallback(() => {
+    const currentQuery = queryStringManager.getQuery()?.query || "";
+    const currentTime = timefilter.getTime() || {};
+    const shareState = encodeShareState({
+      version: SHARE_STATE_VERSION,
+      columns: state.columns || [],
+      filters: filterManager.getFilters() || [],
+      histogramVisible,
+      mode,
+      sort: state.sort || [],
+      timeField: indexPattern.timeFieldName || "",
+    });
+
+    return updateHashQueryParams(window.location.href, {
+      columns: state.columns,
+      index: indexPattern.type === "index" ? indexPattern.id : undefined,
+      query: currentQuery,
+      share: shareState || undefined,
+      sq: undefined,
+      time: [currentTime.from, currentTime.to],
+      viewID: indexPattern.type === "index" ? undefined : indexPattern.id,
+    });
+  }, [
+    histogramVisible,
+    indexPattern.id,
+    indexPattern.timeFieldName,
+    indexPattern.type,
+    mode,
+    state.columns,
+    state.sort,
+  ]);
+
+  useEffect(() => {
+    if (
+      !shareParam ||
+      appliedShareRef.current === shareParam ||
+      !indexPattern?.id ||
+      !props.selectedCluster?.id
+    ) {
+      return;
+    }
+
+    const sharedState = decodeShareState(shareParam);
+    appliedShareRef.current = shareParam;
+    if (!sharedState || sharedState.version !== SHARE_STATE_VERSION) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const applySharedState = async () => {
+      let nextIndexPattern = indexPattern;
+      if (
+        sharedState.timeField &&
+        sharedState.timeField !== indexPattern.timeFieldName
+      ) {
+        nextIndexPattern = await services.indexPatternService.get(
+          indexPattern.id,
+          indexPattern.type,
+          props.selectedCluster?.id
+        );
+        if (cancelled) {
+          return;
+        }
+        subscriptions.unsubscribe();
+        nextIndexPattern.timeFieldName = sharedState.timeField;
+        props.changeIndexPattern(nextIndexPattern);
+      }
+
+      if (Array.isArray(sharedState.filters)) {
+        if (sharedState.filters.length > 0) {
+          filterManager.setFilters(sharedState.filters);
+        } else {
+          filterManager.removeAll();
+        }
+      }
+
+      const nextSort =
+        Array.isArray(sharedState.sort) && sharedState.sort.length > 0
+          ? sharedState.sort
+          : sharedState.timeField
+          ? [[sharedState.timeField, "desc"]]
+          : state.sort;
+
+      setState((st) => ({
+        ...st,
+        columns:
+          Array.isArray(sharedState.columns) && sharedState.columns.length > 0
+            ? sharedState.columns
+            : st.columns,
+        sort: nextSort,
+      }));
+
+      if (sharedState.mode) {
+        setMode(sharedState.mode);
+      }
+      if (typeof sharedState.histogramVisible === "boolean") {
+        setHistogramVisible(sharedState.histogramVisible);
+      }
+
+      updateQuery({
+        indexPattern: nextIndexPattern,
+        sort: nextSort,
+      });
+    };
+
+    applySharedState();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shareParam, indexPattern?.id, props.selectedCluster?.id]);
 
   useEffect(() => {
     if (indexPattern) {
@@ -1094,6 +1287,7 @@ const Discover = (props) => {
           <InsightBar
             ref={insightBarRef}
             loading={resultState === "loading"}
+            exportHits={records}
             queries={{
               clusterId: props.selectedCluster?.id,
               indexPattern: indexPattern,
@@ -1111,6 +1305,7 @@ const Discover = (props) => {
             //   layout,
             //   onChange: setLayout,
             // }}
+            getShareUrl={getShareUrl}
             isEmpty={resultState === "none" && queryFrom === 0}
             onQueriesSelect={onQueriesSelect}
             onQueriesRemove={(id) => {
@@ -1587,14 +1782,16 @@ const DiscoverUI = (props) => {
         <Empty 
           description={
             <span>
-              The current cluster has no indices or views
+              {formatMessage({ id: "insight.discover.empty.no_indices_or_views" })}
             </span>
           }
           image={Empty.PRESENTED_IMAGE_SIMPLE}
         >
           {hasAuthority("data.index:all") && (
-            <Link to={"/data/index"}>
-              <Button type="primary">Create Now</Button>
+            <Link key="create-index" to={"/data/index"}>
+              <Button key="create-index-button" type="primary">
+                {formatMessage({ id: "insight.discover.empty.create_now" })}
+              </Button>
             </Link> 
           )}
         </Empty>

--- a/web/src/pages/DataManagement/Document.js
+++ b/web/src/pages/DataManagement/Document.js
@@ -6,7 +6,7 @@ import {
   Col, Form, Row, Select, Input, Card, Icon, Table, InputNumber, Popconfirm,
   Divider, Button, Tooltip, Modal, DatePicker, message, Cascader, List,Radio
 } from 'antd';
-import Editor, {monaco} from '@monaco-editor/react';
+import Editor, { monaco } from '@/components/monaco-editor';
 import moment from 'moment';
 import {createDependencyProposals} from './autocomplete';
 import InputSelect from '@/components/infini/InputSelect';
@@ -264,7 +264,10 @@ class JSONTable extends React.Component{
             <Card title={item.id}
               actions={[
                 <Icon type="edit" key="edit" onClick={()=>this.handleEditClick(item)} />,
-                <Popconfirm title="Sure to delete?" onConfirm={()=>this.handleDeleteClick(item)}>
+                <Popconfirm
+                  title={formatMessage({ id: "app.message.confirm.delete" })}
+                  onConfirm={()=>this.handleDeleteClick(item)}
+                >
                   <Icon type="delete" key="delete" />
                 </Popconfirm>,
               ]}>
@@ -361,7 +364,10 @@ class EditableCell extends React.Component {
                   </a>
                 )}
               </EditableContext.Consumer>
-              <Popconfirm title="Sure to cancel?" onConfirm={() => this.cancel(record.id)}>
+              <Popconfirm
+                title={formatMessage({ id: "document.confirm.cancel" })}
+                onConfirm={() => this.cancel(record.id)}
+              >
                 <a>{formatMessage({id:'form.button.cancel'})}</a>
               </Popconfirm>
             </span>
@@ -370,9 +376,12 @@ class EditableCell extends React.Component {
               {formatMessage({id:'form.button.edit'})}
             </a>
             <Divider type="vertical"/>
-              <Popconfirm title="Sure to delete?" onConfirm={() => this.delete(record)}>
-                <a>{formatMessage({id:'form.button.delete'})}</a>
-              </Popconfirm>
+               <Popconfirm
+                 title={formatMessage({ id: "app.message.confirm.delete" })}
+                 onConfirm={() => this.delete(record)}
+               >
+                 <a>{formatMessage({id:'form.button.delete'})}</a>
+               </Popconfirm>
            </div>
           );
         },

--- a/web/src/pages/DataManagement/IndexLifeCycle.js
+++ b/web/src/pages/DataManagement/IndexLifeCycle.js
@@ -138,7 +138,7 @@ class IndexLifeCycle extends PureComponent {
     {
       title: '操作',
       render: (text, record) => (
-        <Fragment>
+        <Fragment key={record.name}>
           <a onClick={() => this.handleUpdateModalVisible(true, record)}>设置</a>
           <Divider type="vertical" />
           <a onClick={() => {
@@ -334,7 +334,7 @@ class IndexLifeCycle extends PureComponent {
       handleUpdate: this.handleUpdate,
     };
     return (
-      <Fragment>
+      <Fragment key="indexLifeCycle">
         <Card bordered={false}>
           <div className={styles.tableList}>
             <div className={styles.tableListForm}>{this.renderForm()}</div>

--- a/web/src/pages/DataManagement/IndexPatterns.jsx
+++ b/web/src/pages/DataManagement/IndexPatterns.jsx
@@ -23,7 +23,13 @@ import { CreateEditComplexFieldContainer } from "@/components/vendor/index_patte
 
 const IndexPatterns = (props) => {
   if (!props.selectedCluster?.id) {
-    return <Card ><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} /></Card>;
+    return (
+      <PageHeaderWrapper>
+        <Card>
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        </Card>
+      </PageHeaderWrapper>
+    );
   }
   const history = useMemo(() => {
     return new ScopedHistory(props.history, "/data/views");

--- a/web/src/pages/DataManagement/IndexSummary.js
+++ b/web/src/pages/DataManagement/IndexSummary.js
@@ -172,7 +172,7 @@ class IndexSummary extends Component {
   render() {
     let data = JSON.parse(datasource);
     return (
-        <Fragment>
+        <Fragment key="indexSummary">
             <Card>
               <div>
                 <Row>

--- a/web/src/pages/DataManagement/IndexTemplate.js
+++ b/web/src/pages/DataManagement/IndexTemplate.js
@@ -195,7 +195,7 @@ class IndexTemplate extends PureComponent {
     {
       title: '操作',
       render: (text, record) => (
-        <Fragment>
+        <Fragment key={record.name}>
           <a onClick={() => this.handleUpdateModalVisible(true, record)}>设置</a>
           <Divider type="vertical" />
           <a onClick={() => {
@@ -391,7 +391,7 @@ class IndexTemplate extends PureComponent {
       handleUpdate: this.handleUpdate,
     };
     return (
-      <Fragment>
+      <Fragment key="indexTemplate">
         <Card bordered={false}>
           <div className={styles.tableList}>
             <div className={styles.tableListForm}>{this.renderForm()}</div>

--- a/web/src/pages/DataManagement/Insight/InsightBar/index.less
+++ b/web/src/pages/DataManagement/Insight/InsightBar/index.less
@@ -3,6 +3,11 @@
     right: 0px;
     top: 52px;
 
+    .exportActions {
+        display: inline-flex;
+        align-items: center;
+    }
+
     :global {
         .anticon {
             color: #006BB4;

--- a/web/src/pages/DataManagement/Insight/InsightBar/index.tsx
+++ b/web/src/pages/DataManagement/Insight/InsightBar/index.tsx
@@ -9,6 +9,7 @@ import { Icon, message } from "antd";
 import SearchInfo from "../SearchInfo";
 import Histogram from "../Histogram";
 import ViewLayout from "../ViewLayout";
+import { formatMessage } from "umi/locale";
 
 export interface IQueries {
   clusterId: string;
@@ -33,6 +34,7 @@ export interface IRecord {
 
 export interface IProps {
   queries: IQueries;
+  exportHits?: any[];
   loading: boolean;
   isEmpty: boolean;
   mode: string;
@@ -52,11 +54,63 @@ export interface IProps {
   showLayoutListIcon: boolean;
   viewLayout: any;
   onViewLayoutChange: (layout: any) => void;
+  getShareUrl?: () => string;
 }
+
+const normalizeExportValue = (value: any) => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+};
+
+const escapeCSVValue = (value: any) => {
+  const text = normalizeExportValue(value);
+  return `"${text.replace(/"/g, '""')}"`;
+};
+
+const escapeHTML = (value: any) => {
+  return normalizeExportValue(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+};
+
+const sanitizeFileName = (value: string) => {
+  return (value || "insight")
+    .replace(/[\\/:*?"<>|]+/g, "_")
+    .replace(/\s+/g, "_");
+};
+
+const copyText = async (text: string) => {
+  if (!text) {
+    return false;
+  }
+  if (navigator?.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  const input = document.createElement("textarea");
+  input.value = text;
+  input.setAttribute("readonly", "readonly");
+  input.style.position = "fixed";
+  input.style.top = "-9999px";
+  document.body.appendChild(input);
+  input.select();
+  const copied = document.execCommand("copy");
+  document.body.removeChild(input);
+  return copied;
+};
 
 export default forwardRef((props: IProps, ref: any) => {
   const { 
     queries,
+    exportHits = [],
     loading: searchLoading,
     isEmpty,
     mode,
@@ -73,7 +127,8 @@ export default forwardRef((props: IProps, ref: any) => {
     showLayoutListIcon,
     viewLayout,
     onViewLayoutChange,
-    histogramProps = {}
+    histogramProps = {},
+    getShareUrl,
   } = props;
 
   const {
@@ -91,6 +146,105 @@ export default forwardRef((props: IProps, ref: any) => {
   const [data, setData] = useState<IRecord[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
+
+  const getFlattenedHit = (hit: any) => {
+    if (indexPattern?.flattenHit) {
+      return indexPattern.flattenHit(hit, true) || {};
+    }
+    return hit?._source || {};
+  };
+
+  const getExportColumns = () => {
+    const visibleColumns = (columns || []).filter((item) => item);
+    if (visibleColumns.length > 0 && !visibleColumns.includes("_source")) {
+      return visibleColumns;
+    }
+    const fieldSet = new Set<string>();
+    exportHits.forEach((hit) => {
+      Object.keys(getFlattenedHit(hit)).forEach((field) => {
+        fieldSet.add(field);
+      });
+    });
+    return Array.from(fieldSet);
+  };
+
+  const downloadFile = (content: string, type: string, extension: string) => {
+    const baseName = sanitizeFileName(indexPattern?.title || "insight");
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const blob = new Blob(["\ufeff", content], { type });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${baseName}-${timestamp}.${extension}`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  };
+
+  const handleExport = (type: "csv" | "excel") => {
+    if (!exportHits || exportHits.length === 0) {
+      message.warning(formatMessage({ id: "insight.export.empty" }));
+      return;
+    }
+
+    const exportColumns = getExportColumns();
+    if (exportColumns.length === 0) {
+      message.warning(formatMessage({ id: "insight.export.empty" }));
+      return;
+    }
+
+    const rows = exportHits.map((hit) => {
+      const flattened = getFlattenedHit(hit);
+      return exportColumns.map((field) => flattened[field]);
+    });
+
+    if (type === "csv") {
+      const content = [
+        exportColumns.map(escapeCSVValue).join(","),
+        ...rows.map((row) => row.map(escapeCSVValue).join(",")),
+      ].join("\n");
+      downloadFile(content, "text/csv;charset=utf-8;", "csv");
+      return;
+    }
+
+    const content = `
+      <html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">
+        <head>
+          <meta charset="UTF-8" />
+        </head>
+        <body>
+          <table>
+            <thead>
+              <tr>${exportColumns.map((field) => `<th>${escapeHTML(field)}</th>`).join("")}</tr>
+            </thead>
+            <tbody>
+              ${rows
+                .map(
+                  (row) =>
+                    `<tr>${row.map((cell) => `<td>${escapeHTML(cell)}</td>`).join("")}</tr>`
+                )
+                .join("")}
+            </tbody>
+          </table>
+        </body>
+      </html>
+    `;
+    downloadFile(content, "application/vnd.ms-excel;charset=utf-8;", "xls");
+  };
+
+  const handleShare = async () => {
+    try {
+      const shareUrl = getShareUrl?.();
+      const copied = await copyText(shareUrl || "");
+      if (!copied) {
+        throw new Error("copy failed");
+      }
+      message.success(formatMessage({ id: "insight.share.success" }));
+    } catch (error) {
+      message.error(formatMessage({ id: "insight.share.failed" }));
+    }
+  };
 
   const onSelect = (item: IRecord) => {
     setRecord(item)
@@ -212,6 +366,23 @@ export default forwardRef((props: IProps, ref: any) => {
         onClick={() => handleModeChange("table")}
       /> */}
       { !isEmpty && mode !== "table" && <FullScreen onFullScreen={onFullScreen}/> }
+      <span className={styles.exportActions}>
+        <Icon
+          type="share-alt"
+          title={formatMessage({ id: "insight.share.copy" })}
+          onClick={handleShare}
+        />
+        <Icon
+          type="file-text"
+          title={formatMessage({ id: "insight.export.csv" })}
+          onClick={() => handleExport("csv")}
+        />
+        <Icon
+          type="file-excel"
+          title={formatMessage({ id: "insight.export.excel" })}
+          onClick={() => handleExport("excel")}
+        />
+      </span>
       <InsightConfig 
         searchConfig={searchConfig}
         onSearchConfigChange={onSearchConfigChange}

--- a/web/src/pages/DataManagement/Insight/InsightConfig/SearchConfig.tsx
+++ b/web/src/pages/DataManagement/Insight/InsightConfig/SearchConfig.tsx
@@ -1,6 +1,7 @@
 import { Form, Input, InputNumber, Select, Switch, Divider } from "antd";
 import styles from './index.less';
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+import { formatMessage } from "umi/locale";
 
 const InputGroup = Input.Group;
 const { Option } = Select;
@@ -15,10 +16,10 @@ interface IProps {
 }
 
 const timeIntervals = [
-  { label: 'Seconds', value: 's' },
-  { label: 'Minutes', value: 'm' },
-  { label: 'Hours', value: 'h' },
-  { label: 'Days', value: 'd' },
+  { labelId: 'insight.config.search.time_interval.seconds', value: 's' },
+  { labelId: 'insight.config.search.time_interval.minutes', value: 'm' },
+  { labelId: 'insight.config.search.time_interval.hours', value: 'h' },
+  { labelId: 'insight.config.search.time_interval.days', value: 'd' },
 ];
 
 export default (props: IProps) => {
@@ -44,14 +45,14 @@ export default (props: IProps) => {
         className={styles.form}
         colon={false}
       >
-        <Form.Item label="Track Total Hits">
+        <Form.Item label={formatMessage({ id: "insight.config.search.track_total_hits" })}>
             <Switch 
                 size="small"
                 checked={trackTotalHits} 
                 onChange={(checked) => onChange(checked, 'track_total_hits')} 
             />
         </Form.Item>
-        <Form.Item label="TimeOut">
+        <Form.Item label={formatMessage({ id: "insight.config.search.timeout" })}>
           <div style={{ display: 'flex'}}>
             <Input.Group compact>
               <InputNumber
@@ -67,29 +68,29 @@ export default (props: IProps) => {
               <Select value={timeoutObject.unit} onChange={(value) => onChange(`${timeoutObject.value}${value}`, 'time_out')} style={{ width: 100 }}>
                 {timeIntervals.map((item) => (
                     <Select.Option key={item.value} value={item.value}>
-                      {item.label}
+                      {formatMessage({ id: item.labelId })}
                     </Select.Option>
                   ))}
               </Select>
             </Input.Group>
           </div>
         </Form.Item>
-        <Divider orientation="left">Field Summary</Divider>
-        <Form.Item label="Whether to sample">
+        <Divider orientation="left">{formatMessage({ id: "insight.config.search.field_summary" })}</Divider>
+        <Form.Item label={formatMessage({ id: "insight.config.search.whether_to_sample" })}>
             <Switch 
                 size="small"
                 checked={whetherToSample!==undefined ? whetherToSample : true} 
                 onChange={(checked) => onChange(checked, 'whether_to_sample')} 
             />
         </Form.Item>
-        <Form.Item label="Sample records">
+        <Form.Item label={formatMessage({ id: "insight.config.search.sample_records" })}>
         <InputGroup compact>
           <Select
             style={{ width: '30%' }}
             defaultValue={sampleRecords || 'manual'}
             onChange={(value) => onChange(value, 'sample_records')}>
-            <Option key="all" value="all">all records</Option>
-            <Option key="manual" value="manual">manual setting</Option>
+            <Option key="all" value="all">{formatMessage({ id: "insight.config.search.sample_records.all" })}</Option>
+            <Option key="manual" value="manual">{formatMessage({ id: "insight.config.search.sample_records.manual" })}</Option>
           </Select>
           {sampleRecords==='manual'?<InputNumber
             min={1000}
@@ -99,7 +100,7 @@ export default (props: IProps) => {
             onChange={(value) => onChange(value, 'sample_size')} />:null}
         </InputGroup>
         </Form.Item>
-        <Form.Item label="Top number">
+        <Form.Item label={formatMessage({ id: "insight.config.search.top_number" })}>
           <InputNumber
             min={5}
             max={100}

--- a/web/src/pages/DataManagement/Insight/InsightConfig/index.tsx
+++ b/web/src/pages/DataManagement/Insight/InsightConfig/index.tsx
@@ -1,5 +1,6 @@
 import { Drawer, Icon, Tabs } from "antd";
 import { useState } from "react";
+import { formatMessage } from "umi/locale";
 import SearchConfig from "./SearchConfig";
 import LayoutConfig from "./LayoutConfig";
 
@@ -25,17 +26,17 @@ export default (props: IProps) => {
     const { searchConfig, onSearchConfigChange, layoutConfig } = props;
     const [visible, setVisible] = useState(false);
 
-    const [activeKey, setActiveKey] = useState("Search");
+    const [activeKey, setActiveKey] = useState("search");
 
     return (
       <>
         <Icon 
           type={"setting"}
-          title={"Insight Config"}
+          title={formatMessage({ id: "insight.config.title" })}
           onClick={() => setVisible(true)}
         />
         <Drawer
-          title="Insight Config"
+          title={formatMessage({ id: "insight.config.title" })}
           placement="right"
           onClose={() => setVisible(false)}
           visible={visible}
@@ -49,7 +50,7 @@ export default (props: IProps) => {
             onChange={setActiveKey} 
             // tabBarExtraContent={<Icon type="close" onClick={() => setVisible(false)}/>}
           >
-            <Tabs.TabPane tab="Search" key="Search" style={{ padding: 24}}>
+            <Tabs.TabPane tab={formatMessage({ id: "insight.config.tab.search" })} key="search" style={{ padding: 24}}>
               <SearchConfig {...searchConfig} onChange={onSearchConfigChange}/>
             </Tabs.TabPane>
             {/* <Tabs.TabPane tab="Layout" key="Layout" style={{ padding: 24}}>

--- a/web/src/pages/DataManagement/Insight/SearchInfo/index.tsx
+++ b/web/src/pages/DataManagement/Insight/SearchInfo/index.tsx
@@ -4,31 +4,50 @@ import Info, { IProps } from "./Info";
 import styles from './index.scss';
 
 export default (props: IProps & { loading: boolean }) => {
-
-    const { loading, total } = props
+    const { loading, total } = props;
 
     const [showResultCount, setShowResultCount] = useState(true);
-    const timerRef = useRef(null)
-    const autoHiddenRef = useRef(true)
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const autoHiddenRef = useRef(true);
+    const isMountedRef = useRef(true); // 防止卸载后 setState
 
+    // 处理自动隐藏逻辑
     useEffect(() => {
+        if (!showResultCount) return;
+
         if (timerRef.current) {
-            clearTimeout(timerRef.current)
+            clearTimeout(timerRef.current);
         }
-        if (showResultCount) {
-            timerRef.current = setTimeout(() => {
-                if (autoHiddenRef.current) {
-                    setShowResultCount(false)
-                }
-            }, 3000);
-        }
-    }, [showResultCount])
 
+        timerRef.current = setTimeout(() => {
+            if (autoHiddenRef.current && isMountedRef.current) {
+                setShowResultCount(false);
+            }
+        }, 3000);
+
+        // 清理函数
+        return () => {
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+            }
+        };
+    }, [showResultCount]);
+
+    // 更新 autoHiddenRef
     useEffect(() => {
-        if (loading) {
-            autoHiddenRef.current = true
-        }
-    }, [loading])
+        autoHiddenRef.current = loading ? true : autoHiddenRef.current;
+    }, [loading]);
+
+    // 组件卸载时标记
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+            }
+        };
+    }, []);
 
     if (typeof total !== 'number' || total <= 0) return null; 
 
@@ -38,20 +57,21 @@ export default (props: IProps & { loading: boolean }) => {
             placement="left" 
             title={null} 
             overlayClassName={styles.searchInfo}
-            content={(
-            <Info
-                {...props}
-                dateFormat={"YYYY-MM-DD H:mm"}
+            content={
+                <Info
+                    {...props}
+                    dateFormat={"YYYY-MM-DD H:mm"}
+                />
+            }
+        >
+            <Icon
+                type="info-circle"
+                style={{ color: '#006BB4', cursor: 'pointer' }}
+                onClick={() => {
+                    autoHiddenRef.current = showResultCount ? true : false;
+                    setShowResultCount(!showResultCount);
+                }}
             />
-        )}>
-            <Icon type="info-circle" style={{color: '#006BB4', cursor: 'pointer'}} onClick={() => {
-                if (showResultCount) {
-                    autoHiddenRef.current = true
-                } else {
-                    autoHiddenRef.current = false
-                }
-                setShowResultCount(!showResultCount)
-            }}/>
         </Popover>
-    )
+    );
 }

--- a/web/src/pages/DataManagement/SearchFlow/Form.jsx
+++ b/web/src/pages/DataManagement/SearchFlow/Form.jsx
@@ -22,6 +22,7 @@ import { useGlobal } from "@/layouts/GlobalContext";
 export default Form.create({ name: "trace_template_form" })(
   ({ form, history, match }) => {
     const { selectedCluster } = useGlobal();
+    const clusterId = selectedCluster?.id;
     const mode = React.useMemo(() => {
       const { template_id } = match.params;
       if (template_id) {
@@ -34,8 +35,11 @@ export default Form.create({ name: "trace_template_form" })(
       const { template_id } = match.params;
       if (template_id) {
         const fetchData = async () => {
+          if (!clusterId) {
+            return false;
+          }
           const res = await request(
-            `${ESPrefix}/${selectedCluster.id}/trace_template/${template_id}`,
+            `${ESPrefix}/${clusterId}/trace_template/${template_id}`,
             {}
           );
           if (!res || res.error) {
@@ -45,7 +49,7 @@ export default Form.create({ name: "trace_template_form" })(
         };
         fetchData();
       }
-    }, [selectedCluster]);
+    }, [clusterId]);
 
     const handleSubmit = React.useCallback(() => {
       form.validateFields(async (errors, values) => {
@@ -53,8 +57,11 @@ export default Form.create({ name: "trace_template_form" })(
           return;
         }
         let res = null;
+        if (!clusterId) {
+          return false;
+        }
         if (mode == "NEW") {
-          res = request(`${ESPrefix}/${selectedCluster.id}/trace_template`, {
+          res = request(`${ESPrefix}/${clusterId}/trace_template`, {
             method: "POST",
             body: values,
           });
@@ -62,7 +69,7 @@ export default Form.create({ name: "trace_template_form" })(
           const { template_id } = match.params;
 
           res = request(
-            `${ESPrefix}/${selectedCluster.id}/trace_template/${template_id}`,
+            `${ESPrefix}/${clusterId}/trace_template/${template_id}`,
             {
               method: "PUT",
               body: {
@@ -79,7 +86,7 @@ export default Form.create({ name: "trace_template_form" })(
         if (mode == "NEW") form.resetFields();
         message.success("save succeed");
       });
-    }, [selectedCluster, mode, editValue]);
+    }, [clusterId, mode, editValue]);
 
     const { getFieldDecorator } = form;
     const formItemLayout = {
@@ -104,7 +111,7 @@ export default Form.create({ name: "trace_template_form" })(
         },
       },
     };
-    if (!selectedCluster.id) {
+    if (!clusterId) {
       return null;
     }
     return (

--- a/web/src/pages/DataManagement/SearchFlow/SearchFlow.jsx
+++ b/web/src/pages/DataManagement/SearchFlow/SearchFlow.jsx
@@ -24,10 +24,14 @@ import request from "@/utils/request";
 
 export default ({}) => {
   const { selectedCluster } = useGlobal();
+  const clusterId = selectedCluster?.id;
   const handleDeleteClick = useCallback(
     async (id) => {
+      if (!clusterId) {
+        return false;
+      }
       const res = await request(
-        `${ESPrefix}/${selectedCluster.id}/trace_template/${id}`,
+        `${ESPrefix}/${clusterId}/trace_template/${id}`,
         {
           method: "DELETE",
         }
@@ -36,12 +40,12 @@ export default ({}) => {
         return false;
       }
       message.success("delete succeed");
-      setQueryParams({
-        ...queryParams,
+      setQueryParams((st) => ({
+        ...st,
         t: new Date().valueOf(),
-      });
+      }));
     },
-    [selectedCluster]
+    [clusterId]
   );
   const columns = [
     {
@@ -70,12 +74,12 @@ export default ({}) => {
         <div>
           <Link to={`/data/search_flow/edit/${record.id}`}>Edit</Link>
           <Divider type="vertical" />
-          <Popconfirm
-            title="Sure to delete?"
-            onConfirm={() => handleDeleteClick(record.id)}
-          >
-            <a>Delete</a>
-          </Popconfirm>
+           <Popconfirm
+             title={formatMessage({ id: "app.message.confirm.delete" })}
+             onConfirm={() => handleDeleteClick(record.id)}
+           >
+             <a>{formatMessage({ id: "form.button.delete" })}</a>
+           </Popconfirm>
         </div>
       ),
     },
@@ -83,11 +87,12 @@ export default ({}) => {
   const [queryParams, setQueryParams] = React.useState({});
 
   const { loading, error, value } = useFetch(
-    `${ESPrefix}/${selectedCluster.id}/trace_template`,
+    `${ESPrefix}/${clusterId}/trace_template`,
     {
       queryParams: queryParams,
     },
-    [selectedCluster, queryParams]
+    [clusterId, queryParams],
+    !!clusterId
   );
   const { data: templates, total } = React.useMemo(() => {
     if (!value) {
@@ -119,7 +124,7 @@ export default ({}) => {
                 />
               </div>
               <div className="btn-col">
-                <Button type="primary" icon="search" onClick={onSearchClick}>
+                <Button type="primary" onClick={onSearchClick}>
                   {formatMessage({ id: "form.button.search" })}
                 </Button>
               </div>

--- a/web/src/pages/DataManagement/SearchFlow/TraceSearch.jsx
+++ b/web/src/pages/DataManagement/SearchFlow/TraceSearch.jsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { Input, Select, Button } from "antd";
+import { Input, Select } from "antd";
 import useFetch from "@/lib/hooks/use_fetch";
 import { ESPrefix } from "@/services/common";
 import { useGlobal } from "@/layouts/GlobalContext";
@@ -8,13 +8,15 @@ import { on } from "@svgdotjs/svg.js";
 
 export default ({ onTraceIDSearch }) => {
   const { selectedCluster } = useGlobal();
+  const clusterId = selectedCluster?.id;
   const [queryParams, setQueryParams] = React.useState({ size: 1000 });
   const { loading, error, value } = useFetch(
-    `${ESPrefix}/${selectedCluster.id}/trace_template`,
+    `${ESPrefix}/${clusterId}/trace_template`,
     {
       queryParams: queryParams,
     },
-    [selectedCluster, queryParams]
+    [clusterId, queryParams],
+    !!clusterId
   );
   const [selectedTemplate, setSelectedTemplate] = React.useState();
   const { data: templates, total } = React.useMemo(() => {
@@ -63,11 +65,7 @@ export default ({ onTraceIDSearch }) => {
           size="large"
           style={{ width: "60%" }}
           placeholder="Input trace field value"
-          enterButton={
-            <Button icon="search" type="primary">
-              搜索
-            </Button>
-          }
+          disabled={!clusterId}
           onSearch={onTraceSearch}
         />
       </Input.Group>

--- a/web/src/pages/DataManagement/View/LayoutList.jsx
+++ b/web/src/pages/DataManagement/View/LayoutList.jsx
@@ -141,7 +141,7 @@ export default withRouter((props) => {
 
           return (
             isView ? (
-              <Fragment>
+              <Fragment key={record.id}>
                   {
                     selectedRow?.id !== record.id && (
                       <a onClick={() => {
@@ -153,7 +153,7 @@ export default withRouter((props) => {
                   { defaultAction }
               </Fragment>
             ) : (
-              <Fragment>
+              <Fragment key={record.id}>
                   <Link to={`patterns/${viewId}/layout/${record.id}/edit`}>
                     Edit
                   </Link>

--- a/web/src/pages/DataManagement/View/Widget/WidgetConfig/WidgetConfigDrawer.jsx
+++ b/web/src/pages/DataManagement/View/Widget/WidgetConfig/WidgetConfigDrawer.jsx
@@ -42,7 +42,7 @@ export default (props) => {
             padding: 0,
             height: "calc(100vh - 55px)",
           }}
-          wrapClassName={styles.widgetConfig}
+          className={styles.widgetConfig}
           onClose={() => onVisibleChange(false)}
           destroyOnClose
       >

--- a/web/src/pages/DataManagement/View/WidgetLoader.jsx
+++ b/web/src/pages/DataManagement/View/WidgetLoader.jsx
@@ -11,8 +11,18 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import { formatMessage } from "umi/locale";
 
 export const WidgetRender = (props) => {
-
-   const { widget, range, query, queryParams = {}, highlightRange = {}, refresh, showCopy = true } = props;
+ 
+   const {
+      widget,
+      range,
+      query,
+      queryParams = {},
+      highlightRange = {},
+      refresh,
+      showCopy = true,
+      onGlobalQueriesChange = () => {},
+      onHighlightRangeChange = () => {},
+   } = props;
    const [globalRangeCache, setGlobalRangeCache] = useState()
    const [requests, setRequests] = useState([])
 
@@ -71,20 +81,20 @@ export const WidgetRender = (props) => {
                   hideHeader: true,
                   hideBorder: true,
                }}
-               globalRangeCache={globalRangeCache}
-               onGlobalRangeCacheChange={setGlobalRangeCache}
-               onGlobalQueriesChange={() => {}}
-               onClone={() => {}}
-               onRemove={() => {}}
-               onSave={() => {}}
-               onFullElement={() => {}}
-               clusterList={[]}
-               highlightRange={highlightRange}
-               onHighlightRangeChange={() => {}}
-               onResultChange={(res) => {
-                  setRequests(Array.isArray(res) ? res.filter((item) => !!item.request).map((item) => item.request) : [])
-               }}
-               refresh={refresh}
+                globalRangeCache={globalRangeCache}
+                onGlobalRangeCacheChange={setGlobalRangeCache}
+                onGlobalQueriesChange={onGlobalQueriesChange}
+                onClone={() => {}}
+                onRemove={() => {}}
+                onSave={() => {}}
+                onFullElement={() => {}}
+                clusterList={[]}
+                highlightRange={highlightRange}
+                onHighlightRangeChange={onHighlightRangeChange}
+                onResultChange={(res) => {
+                   setRequests(Array.isArray(res) ? res.filter((item) => !!item.request).map((item) => item.request) : [])
+                }}
+                refresh={refresh}
             />
          </div>
       ) : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />


### PR DESCRIPTION
## Summary
- polish discover, index pattern, insight, search flow, and view-management pages in one final data-management-focused slice
- refresh the shared vendor discover/data/index-pattern components these pages depend on
- keep this PR frontend-only and exclude the overlapping setup test file from the remaining branch diff

## Testing
- NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' ./node_modules/.bin/umi build