### PR TITLE
fix: prefer system cluster for default selection

### DIFF
--- a/web/src/models/global.js
+++ b/web/src/models/global.js
@@ -14,6 +14,7 @@ import router from "umi/router";
 import _ from "lodash";
 import { getAuthEnabled, hasAuthority } from "@/utils/authority";
 import { formatMessage } from "umi/locale";
+import { getPreferredCluster } from "@/utils/setup";
 
 // import ReactGA from "react-ga";
 // ReactGA.initialize("G-L0XH1C4CVP");
@@ -169,21 +170,26 @@ export default {
 
         if (!selectedClusterID) {
           const targetID = extractClusterIDFromURL();
-          let idx = data.findIndex((item) => item.id == targetID);
+          let nextSelectedCluster = getPreferredCluster(data, {
+            targetClusterID: targetID,
+          });
 
-          if (idx === -1) {
+          if (!nextSelectedCluster || (targetID && nextSelectedCluster.id !== targetID)) {
             yield put({ type: "fetchClusterStatus" });
             yield take("fetchClusterStatus/@@end");
             let { clusterStatus } = yield select((state) => state.global);
-            idx = data.findIndex((item) => clusterStatus[item.id]?.available);
-            if (idx === -1) idx = 0;
+            const availableCluster = data.find(
+              (item) => clusterStatus[item.id]?.available
+            );
+            nextSelectedCluster =
+              nextSelectedCluster || availableCluster || data[0];
           }
 
           yield put({
             type: "saveData",
             payload: {
-              selectedCluster: data[idx],
-              selectedClusterID: (data[idx] || {}).id,
+              selectedCluster: nextSelectedCluster,
+              selectedClusterID: nextSelectedCluster?.id,
             },
           });
         }

--- a/web/src/pages/DevTool/Console.tsx
+++ b/web/src/pages/DevTool/Console.tsx
@@ -22,6 +22,7 @@ import { ResizeBar } from "@/components/infini/resize_bar";
 import maximizeSvg from "@/assets/window-maximize.svg";
 import restoreSvg from "@/assets/window-restore.svg";
 import ClusterSelect from "@/components/ClusterSelect";
+import { getPreferredCluster } from "@/utils/setup";
 
 const MaximizeIcon = (props = {}) => {
   return <img height="14px" width="14px" {...props} src={maximizeSvg} />;
@@ -143,9 +144,9 @@ function calcHeightToPX(height: string) {
 }
 
 export const ConsoleUI = ({
-  selectedCluster,
-  clusterList,
-  clusterStatus,
+  selectedCluster = {},
+  clusterList = [],
+  clusterStatus = {},
   minimize = false,
   onMinimizeClick,
   resizeable = false,
@@ -158,27 +159,29 @@ export const ConsoleUI = ({
       return cm;
     }
     (clusterList || []).map((cluster: any) => {
-      cluster.status = clusterStatus[cluster.id]?.health?.status;
+      const nextCluster = { ...cluster };
+      nextCluster.status = clusterStatus[cluster.id]?.health?.status;
       if (!clusterStatus[cluster.id]?.available) {
-        cluster.status = "unavailable";
+        nextCluster.status = "unavailable";
       }
-      cm[cluster.id] = cluster;
+      cm[cluster.id] = nextCluster;
     });
     return cm;
   }, [clusterList, clusterStatus]);
   const initialDefaultState = () => {
-    let defaultCluster = selectedCluster;
-    if (!defaultCluster.id) {
-      defaultCluster = clusterList[0];
-    }
-    const defaultActiveKey = `${defaultCluster.id ||
-      ""}:${new Date().valueOf()}`;
-    const defaultState = defaultCluster
+    const defaultCluster = getPreferredCluster(clusterList, {
+      selectedClusterID: selectedCluster?.id,
+    });
+    const defaultClusterID = defaultCluster?.id || "";
+    const defaultActiveKey = defaultClusterID
+      ? `${defaultClusterID}:${new Date().valueOf()}`
+      : "";
+    const defaultState = defaultClusterID
       ? {
           panes: [
             {
               key: defaultActiveKey,
-              cluster_id: defaultCluster.id,
+              cluster_id: defaultClusterID,
               title: defaultCluster.name,
             },
           ],
@@ -339,8 +342,8 @@ export const ConsoleUI = ({
     ),
   };
 
-  setClusterID(tabState.activeKey?.split(":")[0]);
-  const panes = tabState.panes.filter((pane: any) => {
+  setClusterID(tabState.activeKey?.split(":")[0] || "");
+  const panes = (tabState.panes || []).filter((pane: any) => {
     pane.closable = true;
     return typeof clusterMap[pane.cluster_id] != "undefined";
   });

--- a/web/src/utils/setup.js
+++ b/web/src/utils/setup.js
@@ -13,3 +13,21 @@ export function isSystemCluster(clusterID){
 export function getSystemClusterID() {
   return 'infini_default_system_cluster';
 }
+
+export function getPreferredCluster(clusters = [], options = {}) {
+  if (!Array.isArray(clusters) || clusters.length === 0) {
+    return null;
+  }
+
+  const { selectedClusterID, targetClusterID } = options;
+  const findCluster = (clusterID) =>
+    clusterID ? clusters.find((item) => item.id === clusterID) : null;
+
+  return (
+    findCluster(selectedClusterID) ||
+    findCluster(targetClusterID) ||
+    findCluster(getSystemClusterID()) ||
+    clusters[0] ||
+    null
+  );
+}


### PR DESCRIPTION
## Summary\n- add a shared helper to choose the preferred cluster with system-cluster fallback\n- use the helper when initializing the global selected cluster\n- use the same preference logic when opening Dev Tools tabs\n\n## Validation\n- cd web && NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' ./node_modules/.bin/umi build\n\nStacked on #301.