### PR TITLE
fix: restrict overview logs to elasticsearch category

### DIFF
--- a/web/src/pages/Platform/Overview/Cluster/Monitor/Logs.jsx
+++ b/web/src/pages/Platform/Overview/Cluster/Monitor/Logs.jsx
@@ -19,6 +19,11 @@ export default (props) => {
             queryFilters={[
                 {
                     "term": {
+                        "metadata.category": "elasticsearch"
+                    }
+                },
+                {
+                    "term": {
                         "metadata.labels.cluster_id": clusterID
                     }
                 }

--- a/web/src/pages/Platform/Overview/Node/Monitor/Logs.jsx
+++ b/web/src/pages/Platform/Overview/Node/Monitor/Logs.jsx
@@ -17,6 +17,11 @@ export default (props) => {
             queryFilters={[
                 {
                     "term": {
+                        "metadata.category": "elasticsearch"
+                    }
+                },
+                {
+                    "term": {
                         "metadata.labels.node_uuid": nodeID
                     }
                 }


### PR DESCRIPTION
## Summary
- add an elasticsearch category filter to cluster overview logs
- add the same category filter to node overview logs
- keep task logs out of cluster log views