### PR TITLE
fix: keep alert rule status neutral until alert info loads

### DIFF
--- a/plugin/api/alerting/rule.go
+++ b/plugin/api/alerting/rule.go
@@ -736,6 +736,162 @@ func (alertAPI *AlertAPI) getRuleAlertMessageNumbers(ruleIDs []string) (map[stri
 	return ruleAlertNumbers, nil
 }
 
+type alertInfoSearchFieldConfig struct {
+	RuleIDField string
+	StateField  string
+}
+
+var alertInfoSearchFieldConfigs = []alertInfoSearchFieldConfig{
+	{
+		RuleIDField: "rule_id",
+		StateField:  "state",
+	},
+}
+
+func searchLatestAlertsByField(esClient elastic.API, ruleIDs []string, fieldConfig alertInfoSearchFieldConfig, sourceFields []string, alertState string) (*elastic.SearchResponse, error) {
+	queryDsl := util.MapStr{
+		"_source": sourceFields,
+		"sort": []util.MapStr{
+			{
+				"created": util.MapStr{
+					"order": "desc",
+				},
+			},
+		},
+		"collapse": util.MapStr{
+			"field": fieldConfig.RuleIDField,
+		},
+	}
+
+	if alertState == "" {
+		queryDsl["query"] = util.MapStr{
+			"terms": util.MapStr{
+				fieldConfig.RuleIDField: ruleIDs,
+			},
+		}
+	} else {
+		queryDsl["query"] = util.MapStr{
+			"bool": util.MapStr{
+				"must": []util.MapStr{
+					{
+						"terms": util.MapStr{
+							fieldConfig.RuleIDField: ruleIDs,
+						},
+					},
+					{
+						"term": util.MapStr{
+							fieldConfig.StateField: util.MapStr{
+								"value": alertState,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return esClient.SearchWithRawQueryDSL(orm.GetWildcardIndexName(alerting.Alert{}), util.MustToJSONBytes(queryDsl))
+}
+
+func getRemainingRuleIDs(ruleIDs []string, found map[string]struct{}) []string {
+	remaining := make([]string, 0, len(ruleIDs))
+	for _, ruleID := range ruleIDs {
+		if _, ok := found[ruleID]; ok {
+			continue
+		}
+		remaining = append(remaining, ruleID)
+	}
+	return remaining
+}
+
+func fetchLatestRuleStatuses(esClient elastic.API, ruleIDs []string) (map[string]util.MapStr, []string) {
+	results := map[string]util.MapStr{}
+	found := map[string]struct{}{}
+	remaining := append([]string(nil), ruleIDs...)
+	attempts := make([]string, 0, len(alertInfoSearchFieldConfigs))
+
+	for _, fieldConfig := range alertInfoSearchFieldConfigs {
+		if len(remaining) == 0 {
+			break
+		}
+
+		searchRes, err := searchLatestAlertsByField(esClient, remaining, fieldConfig, []string{"state", "rule_id"}, "")
+		if err != nil {
+			attempts = append(attempts, fmt.Sprintf("%s query failed: %v", fieldConfig.RuleIDField, err))
+			continue
+		}
+		if len(searchRes.Hits.Hits) == 0 {
+			attempts = append(attempts, fmt.Sprintf("%s query returned no hits", fieldConfig.RuleIDField))
+			continue
+		}
+
+		matched := 0
+		for _, hit := range searchRes.Hits.Hits {
+			ruleID, ok := hit.Source["rule_id"].(string)
+			if !ok || ruleID == "" {
+				continue
+			}
+			results[ruleID] = util.MapStr{
+				"status": hit.Source["state"],
+			}
+			found[ruleID] = struct{}{}
+			matched++
+		}
+		attempts = append(attempts, fmt.Sprintf("%s query matched %d rule(s)", fieldConfig.RuleIDField, matched))
+		remaining = getRemainingRuleIDs(ruleIDs, found)
+	}
+
+	return results, attempts
+}
+
+func fetchLatestRuleNotificationTimes(esClient elastic.API, ruleIDs []string) (map[string]interface{}, []string) {
+	results := map[string]interface{}{}
+	found := map[string]struct{}{}
+	remaining := append([]string(nil), ruleIDs...)
+	attempts := make([]string, 0, len(alertInfoSearchFieldConfigs))
+
+	for _, fieldConfig := range alertInfoSearchFieldConfigs {
+		if len(remaining) == 0 {
+			break
+		}
+
+		searchRes, err := searchLatestAlertsByField(esClient, remaining, fieldConfig, []string{"created", "rule_id"}, alerting.AlertStateAlerting)
+		if err != nil {
+			attempts = append(attempts, fmt.Sprintf("%s notification query failed: %v", fieldConfig.RuleIDField, err))
+			continue
+		}
+		if len(searchRes.Hits.Hits) == 0 {
+			attempts = append(attempts, fmt.Sprintf("%s notification query returned no hits", fieldConfig.RuleIDField))
+			continue
+		}
+
+		matched := 0
+		for _, hit := range searchRes.Hits.Hits {
+			ruleID, ok := hit.Source["rule_id"].(string)
+			if !ok || ruleID == "" {
+				continue
+			}
+			results[ruleID] = hit.Source["created"]
+			found[ruleID] = struct{}{}
+			matched++
+		}
+		attempts = append(attempts, fmt.Sprintf("%s notification query matched %d rule(s)", fieldConfig.RuleIDField, matched))
+		remaining = getRemainingRuleIDs(ruleIDs, found)
+	}
+
+	return results, attempts
+}
+
+func buildRuleStatusUnavailableReason(statusAttempts []string) string {
+	if len(statusAttempts) == 0 {
+		return "latest alert status unavailable: no alert history found for this rule yet"
+	}
+	return fmt.Sprintf(
+		"latest alert status unavailable: no matching alert history found for this rule yet (attempts: %s)",
+		strings.Join(statusAttempts, "; "),
+	)
+}
+
 func (alertAPI *AlertAPI) fetchAlertInfos(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	var ruleIDs = []string{}
 	alertAPI.DecodeJSON(req, &ruleIDs)
@@ -745,90 +901,26 @@ func (alertAPI *AlertAPI) fetchAlertInfos(w http.ResponseWriter, req *http.Reque
 		return
 	}
 	esClient := elastic.GetClient(global.MustLookupString(elastic.GlobalSystemElasticsearchID))
-	queryDsl := util.MapStr{
-		"_source": []string{"state", "rule_id"},
-		"sort": []util.MapStr{
-			{
-				"created": util.MapStr{
-					"order": "desc",
-				},
-			},
-		},
-		"collapse": util.MapStr{
-			"field": "rule_id",
-		},
-		"query": util.MapStr{
-			"terms": util.MapStr{
-				"rule_id": ruleIDs,
-			},
-		},
-	}
+	latestAlertInfos, statusAttempts := fetchLatestRuleStatuses(esClient, ruleIDs)
+	lastNotificationTimes, _ := fetchLatestRuleNotificationTimes(esClient, ruleIDs)
 
-	searchRes, err := esClient.SearchWithRawQueryDSL(orm.GetWildcardIndexName(alerting.Alert{}), util.MustToJSONBytes(queryDsl))
-	if err != nil {
-		log.Error(err)
-		alertAPI.WriteError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if len(searchRes.Hits.Hits) == 0 {
-		alertAPI.WriteJSON(w, util.MapStr{}, http.StatusOK)
-		return
-	}
-
-	latestAlertInfos := map[string]util.MapStr{}
-	for _, hit := range searchRes.Hits.Hits {
-		if ruleID, ok := hit.Source["rule_id"].(string); ok {
-			latestAlertInfos[ruleID] = util.MapStr{
-				"status": hit.Source["state"],
+	response := make(util.MapStr, len(ruleIDs))
+	for _, ruleID := range ruleIDs {
+		info := util.MapStr{}
+		if latestInfo, ok := latestAlertInfos[ruleID]; ok {
+			for k, v := range latestInfo {
+				info[k] = v
 			}
 		}
-	}
-	queryDsl = util.MapStr{
-		"_source": []string{"created", "rule_id"},
-		"sort": []util.MapStr{
-			{
-				"created": util.MapStr{
-					"order": "desc",
-				},
-			},
-		},
-		"collapse": util.MapStr{
-			"field": "rule_id",
-		},
-		"query": util.MapStr{
-			"bool": util.MapStr{
-				"must": []util.MapStr{
-					{
-						"terms": util.MapStr{
-							"rule_id": ruleIDs,
-						},
-					},
-					{
-						"term": util.MapStr{
-							"state": util.MapStr{
-								"value": alerting.AlertStateAlerting,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	searchRes, err = esClient.SearchWithRawQueryDSL(orm.GetWildcardIndexName(alerting.Alert{}), util.MustToJSONBytes(queryDsl))
-	if err != nil {
-		log.Error(err)
-		alertAPI.WriteError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	for _, hit := range searchRes.Hits.Hits {
-		if ruleID, ok := hit.Source["rule_id"].(string); ok {
-			if _, ok = latestAlertInfos[ruleID]; ok {
-				latestAlertInfos[ruleID]["last_notification_time"] = hit.Source["created"]
-			}
+		if lastNotificationTime, ok := lastNotificationTimes[ruleID]; ok {
+			info["last_notification_time"] = lastNotificationTime
 		}
-
+		if _, ok := info["status"]; !ok {
+			info["status_error"] = buildRuleStatusUnavailableReason(statusAttempts)
+		}
+		response[ruleID] = info
 	}
-	alertAPI.WriteJSON(w, latestAlertInfos, http.StatusOK)
+	alertAPI.WriteJSON(w, response, http.StatusOK)
 }
 
 func (alertAPI *AlertAPI) enableRule(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {

--- a/web/src/pages/Alerting/Rule/Index.jsx
+++ b/web/src/pages/Alerting/Rule/Index.jsx
@@ -8,6 +8,7 @@ import {
   Modal,
   Tag,
   Switch,
+  Tooltip,
 } from "antd";
 import {
   useCallback,
@@ -59,18 +60,46 @@ export default (props) => {
     if (!ids || ids.length == 0) {
       return;
     }
-    let ruleInfo = await request(`/alerting/rule/info`, {
-      method: "POST",
-      body: ids,
-    });
+    try {
+      let ruleInfo = await request(`/alerting/rule/info`, {
+        method: "POST",
+        body: ids,
+      });
 
-    if (ruleInfo && !ruleInfo.error) {
+      const requestError = ruleInfo?.error;
       let tableData = dataSource?.data?.map((item) => {
-        item.info = ruleInfo?.[item.id] || {};
+        item.info =
+          ruleInfo?.[item.id] ||
+          (requestError
+            ? {
+                status_error: requestError,
+              }
+            : {});
+        item.infoLoaded = true;
         return item;
       });
       dataSource.data = tableData;
       // update dataSource
+      setTimeout(() => {
+        if (ref.current?.setDataSource) {
+          ref.current.setDataSource({ ...dataSource, data: tableData });
+        }
+      }, 500);
+    } catch (error) {
+      const errorMessage =
+        error?.message ||
+        formatMessage({
+          id: "alert.rule.status.load_failed",
+          defaultMessage: "Failed to load the latest alert status for this rule",
+        });
+      let tableData = dataSource?.data?.map((item) => {
+        item.info = {
+          status_error: errorMessage,
+        };
+        item.infoLoaded = true;
+        return item;
+      });
+      dataSource.data = tableData;
       setTimeout(() => {
         if (ref.current?.setDataSource) {
           ref.current.setDataSource({ ...dataSource, data: tableData });
@@ -245,6 +274,19 @@ export default (props) => {
     return dataNew;
   };
 
+  const renderRuleStatus = (record) => {
+    if (!record?.infoLoaded) {
+      return <span style={{ width: 14, height: 14, display: "inline-block" }} />;
+    }
+    const indicator = (
+      <HealthStatusCircle status={RuleStautsColor[record.info?.status] || "gray"} />
+    );
+    if (record.info?.status_error) {
+      return <Tooltip title={record.info.status_error}>{indicator}</Tooltip>;
+    }
+    return indicator;
+  };
+
   const columns = [
     {
       title: formatMessage({ id: "alert.rule.table.columnns.category" }),
@@ -272,7 +314,7 @@ export default (props) => {
             to={`/alerting/rule/${record.id}`}
             style={{ display: "flex", alignItems: "center", gap: 5 }}
           >
-            <HealthStatusCircle status={RuleStautsColor[record.info?.status]} />
+            {renderRuleStatus(record)}
             <span>{text}</span>
           </Link>
         );
@@ -421,8 +463,9 @@ export default (props) => {
           getExtra: (props) => [
             hasAuthority("alerting.rule:all")
               ? [
-                  <>
+                  <Fragment key="rule-import-export">
                     <Button
+                      key="rule-import"
                       type="primary"
                       icon="upload"
                       onClick={() => {
@@ -467,8 +510,9 @@ export default (props) => {
                         },
                       ]}
                     />
-                  </>,
+                  </Fragment>,
                   <Button
+                    key="rule-create"
                     type="primary"
                     icon="plus"
                     onClick={() => router.push(`/alerting/rule/new`)}
@@ -484,6 +528,7 @@ export default (props) => {
             hasAuthority("alerting.rule:all")
               ? [
                   <Button
+                    key="rule-enable"
                     type="primary"
                     icon="check-circle"
                     onClick={() => {
@@ -496,6 +541,7 @@ export default (props) => {
                     {formatMessage({ id: "form.button.enable" })}
                   </Button>,
                   <Button
+                    key="rule-disable"
                     type="danger"
                     icon="stop"
                     onClick={() => {
@@ -508,6 +554,7 @@ export default (props) => {
                     {formatMessage({ id: "form.button.disable" })}
                   </Button>,
                   <Button
+                    key="rule-export"
                     type="primary"
                     icon="download"
                     onClick={() => {
@@ -517,6 +564,7 @@ export default (props) => {
                     {formatMessage({ id: "form.button.export" })}
                   </Button>,
                   <Button
+                    key="rule-delete"
                     type="danger"
                     icon="delete"
                     onClick={() => {


### PR DESCRIPTION
## Summary
- fall back gracefully when latest alert status lookups return no matching alert history
- return a neutral status with a tooltip instead of showing a false state
- keep last notification timestamps when available