### PR TITLE
fix: keep ILM and template lifecycle settings compatible with Easysearch

### DIFF
--- a/modules/elastic/api/ilm.go
+++ b/modules/elastic/api/ilm.go
@@ -28,12 +28,85 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	log "github.com/cihub/seelog"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/elastic"
+	"infini.sh/framework/core/util"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 )
+
+type rawRequester interface {
+	Request(ctx context.Context, method, url string, body []byte) (*util.Result, error)
+}
+
+func rawJSONRequest(clusterID, method, path string, body []byte) (map[string]interface{}, int, error) {
+	cfg := elastic.GetConfig(clusterID)
+	client := elastic.GetClient(clusterID)
+	requester, ok := client.(rawRequester)
+	if !ok {
+		return nil, 0, fmt.Errorf("cluster client does not support raw requests")
+	}
+	requestURL := fmt.Sprintf("%s%s", strings.TrimRight(cfg.GetAnyEndpoint(), "/"), path)
+	resp, err := requester.Request(context.Background(), method, requestURL, body)
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, resp.StatusCode, nil
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, resp.StatusCode, fmt.Errorf("%s", resp.Body)
+	}
+	if len(resp.Body) == 0 {
+		return map[string]interface{}{}, resp.StatusCode, nil
+	}
+	result := map[string]interface{}{}
+	if err := util.FromJSONBytes(resp.Body, &result); err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return result, resp.StatusCode, nil
+}
+
+func parseInt64(value interface{}) int64 {
+	switch v := value.(type) {
+	case json.Number:
+		i, _ := v.Int64()
+		return i
+	case float64:
+		return int64(v)
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case string:
+		i, _ := strconv.ParseInt(v, 10, 64)
+		return i
+	default:
+		return 0
+	}
+}
+
+func putEasysearchILMPolicy(clusterID, policy string, policyConfig []byte) error {
+	path := "/_ilm/policy/" + url.PathEscape(policy)
+	current, statusCode, err := rawJSONRequest(clusterID, util.Verb_GET, path, nil)
+	if err != nil && statusCode != http.StatusNotFound {
+		return err
+	}
+	if statusCode != http.StatusNotFound {
+		seqNo := parseInt64(current["_seq_no"])
+		primaryTerm := parseInt64(current["_primary_term"])
+		path += fmt.Sprintf("?if_seq_no=%d&if_primary_term=%d", seqNo, primaryTerm)
+	}
+	_, _, err = rawJSONRequest(clusterID, util.Verb_PUT, path, policyConfig)
+	return err
+}
 
 func (h *APIHandler) HandleGetILMPolicyAction(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	clusterID := ps.MustGetParameter("id")
@@ -51,13 +124,18 @@ func (h *APIHandler) HandleSaveILMPolicyAction(w http.ResponseWriter, req *http.
 	clusterID := ps.MustGetParameter("id")
 	policy := ps.MustGetParameter("policy")
 	esClient := elastic.GetClient(clusterID)
+	cfg := elastic.GetConfig(clusterID)
 	reqBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Error(err)
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	err = esClient.PutILMPolicy(policy, reqBody)
+	if strings.EqualFold(cfg.Distribution, elastic.Easysearch) {
+		err = putEasysearchILMPolicy(clusterID, policy, reqBody)
+	} else {
+		err = esClient.PutILMPolicy(policy, reqBody)
+	}
 	if err != nil {
 		log.Error(err)
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)

--- a/web/src/lib/elasticsearch/ilm.ts
+++ b/web/src/lib/elasticsearch/ilm.ts
@@ -6,17 +6,21 @@ type TransformOptions = {
 }
 
 export const transform = (config: any, options: TransformOptions) => {
-  if(options.sourceDistribution === SearchEngines.Opensearch){
-    return transformOpensearchToElasticsearch(config);
+  if(returnsInternalILMPolicy(options.sourceDistribution) && options.targetDistribution !== SearchEngines.Opensearch){
+    return transformISMToElasticsearch(config);
   }
-  if(options.targetDistribution === SearchEngines.Opensearch){
-    return transformElasticsearchToOpensearch(config);
+  if(options.sourceDistribution !== SearchEngines.Opensearch && options.targetDistribution === SearchEngines.Opensearch){
+    return transformElasticsearchToISM(config);
   }
   
   return config
 }
 
-const transformElasticsearchToOpensearch = (config: any) =>{
+const returnsInternalILMPolicy = (distribution: string) => {
+  return distribution === SearchEngines.Opensearch || distribution === SearchEngines.Easysearch;
+}
+
+const transformElasticsearchToISM = (config: any) =>{
   if(!config || !config.policy){
     return {};
   }
@@ -32,11 +36,17 @@ const transformElasticsearchToOpensearch = (config: any) =>{
     policy["states"] = transformPhases(policy["phases"]);
     delete policy["phases"];
   }
-  policy["description"] = "tranform with infini console";
-  policy["default_state"] = policy.states[0]?.name;
-  policy["ism_template"] = {
-    "index_patterns": [],
-    "priority": 100
+  if(!policy["description"]){
+    policy["description"] = "tranform with infini console";
+  }
+  if(!policy["default_state"]){
+    policy["default_state"] = policy.states?.[0]?.name;
+  }
+  if(!policy["ism_template"]){
+    policy["ism_template"] = {
+      "index_patterns": [],
+      "priority": 100
+    }
   }
   return config;
 }
@@ -52,16 +62,25 @@ const transformPhases = (phases: any)=>{
         "transitions": [],
       }
       Object.keys(phases[pk].actions).forEach(key => {
-        if(pk === "delete"){
-          delete  phases[pk].actions[key]["delete_searchable_snapshot"];
-        }
         //transform action key
         let tkey = key;
         if(key === "set_priority"){
           tkey = "index_priority";
+        } else if(key === "allocate"){
+          tkey = "allocation";
+        } else if(key === "forcemerge"){
+          tkey = "force_merge";
+        } else if(key === "readonly"){
+          tkey = "read_only";
         }
         //transform action value
         let tvalue = phases[pk].actions[key];
+        if(tvalue && typeof tvalue === "object" && !Array.isArray(tvalue)){
+          tvalue = { ...tvalue };
+        }
+        if(pk === "delete" && tvalue && typeof tvalue === "object"){
+          delete tvalue["delete_searchable_snapshot"];
+        }
         if(key === "rollover"){
           tvalue = transformRollover(tvalue, true)
         }
@@ -96,7 +115,7 @@ const transformPhases = (phases: any)=>{
   return states;
 }
 
-const transformOpensearchToElasticsearch = (config: any)=>{
+const transformISMToElasticsearch = (config: any)=>{
   if(!config || !config.policy){
     return {};
   }
@@ -123,20 +142,32 @@ const transformStates = (states: any[])=>{
   states.forEach((st)=>{
     const actions = {};
     (st.actions || []).forEach((action: any)=>{
-      const ak = Object.keys(action).shift();
-      if(!ak) {
-        return;
-      }
-      let tkey = ak;
-      let tvalue = action[ak];
-      if(tkey === "rollover"){
-        tvalue = transformRollover(tvalue, false);
-      }
-      //transform key
-      if(tkey === "index_priority"){
-        tkey = "set_priority";
-      }
-      actions[tkey] = tvalue
+      Object.keys(action || {}).forEach((ak)=>{
+        if(ak === "retry" || ak === "timeout"){
+          return;
+        }
+        let tkey = ak;
+        let tvalue = action[ak];
+        if(tvalue && typeof tvalue === "object" && !Array.isArray(tvalue)){
+          tvalue = { ...tvalue };
+        }
+        if(tkey === "rollover"){
+          tvalue = transformRollover(tvalue, false);
+        }
+        if(tkey === "index_priority"){
+          tkey = "set_priority";
+        } else if(tkey === "allocation"){
+          tkey = "allocate";
+          if(tvalue && typeof tvalue === "object"){
+            delete tvalue.wait_for;
+          }
+        } else if(tkey === "force_merge"){
+          tkey = "forcemerge";
+        } else if(tkey === "read_only"){
+          tkey = "readonly";
+        }
+        actions[tkey] = tvalue
+      })
     })
     phases[st.name] = {
       actions

--- a/web/src/lib/elasticsearch/template.ts
+++ b/web/src/lib/elasticsearch/template.ts
@@ -30,11 +30,113 @@ export const transform = (tpl: any, options: TransformOptions) => {
         delete tpl["template"];
       }
   }
-  if(options.sourceDistribution != SearchEngines.Opensearch && options.targetDistribution === SearchEngines.Opensearch){
-    if(tpl.settings?.index?.lifecycle){
-      tpl.settings.index["plugins.index_state_management.rollover_alias"] = tpl.settings.index.lifecycle.rollover_alias;
-      delete tpl.settings.index["lifecycle"];
+  if(options.sourceDistribution !== SearchEngines.Opensearch && options.targetDistribution === SearchEngines.Opensearch){
+    tpl = transformElasticsearchTemplateLifecycleToISM(tpl);
+  } else if(options.sourceDistribution === SearchEngines.Opensearch && options.targetDistribution !== SearchEngines.Opensearch){
+    tpl = transformISMTemplateLifecycleToElasticsearch(tpl);
+  }
+  return tpl;
+}
+
+const ensureIndexSettings = (tpl: any) => {
+  tpl.settings = tpl.settings || {};
+  tpl.settings.index = tpl.settings.index || {};
+  return tpl.settings.index;
+}
+
+const readElasticsearchLifecycleSetting = (settings: any, key: string) => {
+  if(!settings){
+    return;
+  }
+  const flatValue = settings[`index.lifecycle.${key}`];
+  if(flatValue !== undefined){
+    return flatValue;
+  }
+  const indexSettings = settings.index || {};
+  const nestedValue = indexSettings?.lifecycle?.[key];
+  if(nestedValue !== undefined){
+    return nestedValue;
+  }
+  return indexSettings?.[`lifecycle.${key}`];
+}
+
+const readISMSetting = (settings: any, key: string) => {
+  if(!settings){
+    return;
+  }
+  const flatValue = settings[`index.plugins.index_state_management.${key}`];
+  if(flatValue !== undefined){
+    return flatValue;
+  }
+  const indexSettings = settings.index || {};
+  return indexSettings?.[`plugins.index_state_management.${key}`];
+}
+
+const deleteElasticsearchLifecycleSettings = (settings: any) => {
+  if(!settings){
+    return;
+  }
+  delete settings["index.lifecycle.name"];
+  delete settings["index.lifecycle.rollover_alias"];
+  const indexSettings = settings.index || {};
+  delete indexSettings["lifecycle.name"];
+  delete indexSettings["lifecycle.rollover_alias"];
+  if(indexSettings.lifecycle){
+    delete indexSettings.lifecycle.name;
+    delete indexSettings.lifecycle.rollover_alias;
+    if(Object.keys(indexSettings.lifecycle).length === 0){
+      delete indexSettings.lifecycle;
     }
+  }
+}
+
+const deleteISMSettings = (settings: any) => {
+  if(!settings){
+    return;
+  }
+  delete settings["index.plugins.index_state_management.policy_id"];
+  delete settings["index.plugins.index_state_management.rollover_alias"];
+  const indexSettings = settings.index || {};
+  delete indexSettings["plugins.index_state_management.policy_id"];
+  delete indexSettings["plugins.index_state_management.rollover_alias"];
+}
+
+const transformElasticsearchTemplateLifecycleToISM = (tpl: any) => {
+  const settings = tpl.settings;
+  if(!settings){
+    return tpl;
+  }
+  const policyID = readElasticsearchLifecycleSetting(settings, "name");
+  const rolloverAlias = readElasticsearchLifecycleSetting(settings, "rollover_alias");
+  deleteElasticsearchLifecycleSettings(settings);
+  const indexSettings = ensureIndexSettings(tpl);
+  if(policyID !== undefined){
+    indexSettings["plugins.index_state_management.policy_id"] = policyID;
+  }
+  if(rolloverAlias !== undefined){
+    indexSettings["plugins.index_state_management.rollover_alias"] = rolloverAlias;
+  }
+  return tpl;
+}
+
+const transformISMTemplateLifecycleToElasticsearch = (tpl: any) => {
+  const settings = tpl.settings;
+  if(!settings){
+    return tpl;
+  }
+  const policyID = readISMSetting(settings, "policy_id");
+  const rolloverAlias = readISMSetting(settings, "rollover_alias");
+  deleteISMSettings(settings);
+  if(policyID === undefined && rolloverAlias === undefined){
+    return tpl;
+  }
+  const indexSettings = ensureIndexSettings(tpl);
+  indexSettings.lifecycle = indexSettings.lifecycle || {};
+  if(policyID !== undefined){
+    indexSettings.lifecycle.name = policyID;
+  }
+  if(rolloverAlias !== undefined){
+    indexSettings.lifecycle.rollover_alias = rolloverAlias;
   }
   return tpl;
 }


### PR DESCRIPTION
## Summary
- save Easysearch ILM policies through raw requests that preserve sequence metadata
- translate ILM/ISM actions more safely between Elasticsearch, OpenSearch, and Easysearch
- migrate template lifecycle settings in both directions without dropping rollover metadata