### PR TITLE
fix: harden setup bootstrap with credential-backed system auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,8 +163,11 @@ func main() {
 
 		module.Start()
 
-		var initFunc = func() {
+		var initFunc = func(startDeferredModules bool) {
 			// check cluster health before initialization, refuse to start if status is red
+			if err := setup1.EnsureSystemClusterBasicAuth(); err != nil {
+				panic(fmt.Errorf("failed to hydrate system cluster auth: %v", err))
+			}
 			sysClusterID := global.MustLookupString(elastic.GlobalSystemElasticsearchID)
 			client := elastic.GetClient(sysClusterID)
 			health, err := client.ClusterHealth(context.Background())
@@ -177,7 +180,7 @@ func main() {
 
 			elastic2.InitTemplate(false)
 
-			if global.Env().SetupRequired() {
+			if startDeferredModules {
 				for _, v := range modules {
 					v.Value.Start()
 				}
@@ -217,9 +220,11 @@ func main() {
 		}
 
 		if !global.Env().SetupRequired() {
-			initFunc()
+			initFunc(false)
 		} else {
-			setup1.RegisterSetupCallback(initFunc)
+			setup1.RegisterSetupCallback(func() {
+				initFunc(true)
+			})
 		}
 
 		if !global.Env().SetupRequired() {

--- a/plugin/setup/setup.go
+++ b/plugin/setup/setup.go
@@ -37,6 +37,8 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"infini.sh/console/core/security"
@@ -71,8 +73,7 @@ import (
 
 // Easysearch auto create ingest user password
 const ingestUser = "infini_ingest"
-
-var ingestPassword = util.GenerateSecureString(20)
+const systemClusterIngestPasswordKey = "SYSTEM_CLUSTER_INGEST_PASSWORD"
 
 type Module struct {
 	api.Handler
@@ -100,19 +101,75 @@ func (module *Module) Setup() {
 }
 
 var setupFinishedCallback = []func(){}
+var setupCallbackOnce sync.Once
+var setupInitializeRunning uint32
 
 func RegisterSetupCallback(f func()) {
 	setupFinishedCallback = append(setupFinishedCallback, f)
 }
 
 func InvokeSetupCallback() {
-	for _, v := range setupFinishedCallback {
-		v()
+	setupCallbackOnce.Do(func() {
+		for _, v := range setupFinishedCallback {
+			v()
+		}
+	})
+}
+
+func getOrCreateIngestPassword() (string, error) {
+	value, err := keystore.GetValue(systemClusterIngestPasswordKey)
+	if err == nil && len(value) > 0 {
+		return string(value), nil
 	}
+	if err != nil && err != keystore2.ErrKeyDoesntExists {
+		return "", err
+	}
+
+	password := util.GenerateSecureString(20)
+	if err := keystore.SetValue(systemClusterIngestPasswordKey, []byte(password)); err != nil {
+		return "", err
+	}
+	return password, nil
+}
+
+func acquireSetupInitialization() bool {
+	return atomic.CompareAndSwapUint32(&setupInitializeRunning, 0, 1)
+}
+
+func releaseSetupInitialization() {
+	atomic.StoreUint32(&setupInitializeRunning, 0)
+}
+
+func EnsureSystemClusterBasicAuth() error {
+	sysClusterID := global.MustLookupString(elastic.GlobalSystemElasticsearchID)
+	conf := elastic.GetConfigNoPanic(sysClusterID)
+	if conf == nil || (conf.BasicAuth != nil && conf.BasicAuth.Username != "") || conf.CredentialID == "" {
+		return nil
+	}
+
+	basicAuth, err := elastic1.GetBasicAuth(conf)
+	if err != nil {
+		return err
+	}
+	if basicAuth == nil {
+		return nil
+	}
+
+	conf.BasicAuth = basicAuth
+	if meta := elastic.GetMetadata(sysClusterID); meta != nil && meta.Config != nil {
+		meta.Config.BasicAuth = basicAuth
+	}
+	elastic.UpdateConfig(*conf)
+	return nil
 }
 
 // Start initializes the module and registers a change event for credentials.
 func (module *Module) Start() error {
+	if !global.Env().SetupRequired() {
+		if err := EnsureSystemClusterBasicAuth(); err != nil {
+			log.Error(err)
+		}
+	}
 	credential.RegisterChangeEvent(func(cred *credential.Credential) {
 		if cred == nil {
 			return
@@ -132,6 +189,11 @@ func (module *Module) Start() error {
 			if err != nil {
 				log.Error(err)
 			}
+			conf.BasicAuth = &basicAuth
+			if meta := elastic.GetMetadata(sysClusterID); meta != nil && meta.Config != nil {
+				meta.Config.BasicAuth = &basicAuth
+			}
+			elastic.UpdateConfig(*conf)
 		}
 	})
 	return nil
@@ -595,7 +657,7 @@ func (module *Module) initialize(w http.ResponseWriter, r *http.Request, ps http
 		},
 	}
 	toSaveCfg.Created = &t
-	err = orm.Save(nil, &toSaveCfg)
+	err = orm.Save(newSetupSaveContext(), &toSaveCfg)
 	if err != nil {
 		panic(err)
 	}
@@ -621,7 +683,7 @@ func (module *Module) initialize(w http.ResponseWriter, r *http.Request, ps http
 		user.Roles = role
 		now := time.Now()
 		user.Created = &now
-		err = orm.Save(nil, &user)
+		err = orm.Save(newSetupSaveContext(), &user)
 		if err != nil {
 			panic(err)
 		}
@@ -641,15 +703,17 @@ func (module *Module) initialize(w http.ResponseWriter, r *http.Request, ps http
 		panic(err)
 	}
 
-	//callback
-	InvokeSetupCallback()
-
 	//place setup lock file
 	setupLock := path.Join(global.Env().GetDataDir(), ".setup_lock")
 	_, err = util.FilePutContent(setupLock, time.Now().String())
 	if err != nil {
 		panic(err)
 	}
+	global.Env().CheckSetup()
+
+	//callback
+	InvokeSetupCallback()
+
 	//update credential state
 	q := util.MapStr{
 		"query": util.MapStr{
@@ -761,11 +825,17 @@ func createCred(name, username, password string) string {
 	now := time.Now()
 	cred.Created = &now
 	cred.Updated = &now
-	err = orm.Save(nil, &cred)
+	err = orm.Save(newSetupSaveContext(), &cred)
 	if err != nil {
 		panic(err)
 	}
 	return cred.ID
+}
+
+func newSetupSaveContext() *orm.Context {
+	ctx := orm.NewContext()
+	ctx.Refresh = orm.WaitForRefresh
+	return ctx
 }
 
 // getYamlData reads a YAML file from the setup directory and returns its content as a byte slice.
@@ -813,9 +883,12 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 	}
 	baseDir := path.Join(global.Env().GetConfigDir(), "setup")
 	var (
-		dslTplFileName = "noop.tpl"
-		useCommon      = true
-		rollupEnabled  = false
+		dslTplFileName   = "noop.tpl"
+		useCommon        = true
+		rollupEnabled    = false
+		agentUsername    = request.Cluster.Username
+		agentPassword    = request.Cluster.Password
+		agentPasswordKey = "SYSTEM_CLUSTER_PASS"
 	)
 	if large, _ := util.VersionCompare(ver.Number, "1.12.1"); large >= 0 {
 		rollupEnabled = true
@@ -845,16 +918,20 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 		dslTplFileName = "view.tpl"
 	case "agent":
 		if ver.Distribution == elastic.Easysearch {
-			err = keystore.SetValue("SYSTEM_CLUSTER_INGEST_PASSWORD", []byte(ingestPassword))
+			agentPassword, err = getOrCreateIngestPassword()
 			if err != nil {
 				panic(err)
 			}
+			agentUsername = ingestUser
+			agentPasswordKey = systemClusterIngestPasswordKey
 			client := elastic.GetClient(GlobalSystemElasticsearchID)
-			if privileges, _ := client.GetPrivileges(); len(privileges) > 0 {
-				err = initIngestUser(client, cfg1.IndexPrefix, ingestUser, ingestPassword)
-				if err != nil {
-					panic(err)
-				}
+			_, err = client.GetPrivileges()
+			if err != nil {
+				panic(err)
+			}
+			err = initIngestUser(client, cfg1.IndexPrefix, agentUsername, agentPassword)
+			if err != nil {
+				panic(err)
 			}
 		}
 		dslTplFileName = "agent.tpl"
@@ -933,17 +1010,9 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 		case "SETUP_ES_PASSWORD":
 			return w.Write([]byte(request.Cluster.Password))
 		case "SETUP_AGENT_USERNAME":
-			if ver.Distribution == elastic.Easysearch {
-				return w.Write([]byte(ingestUser))
-			} else {
-				return w.Write([]byte(request.Cluster.Username))
-			}
-		case "SETUP_AGENT_PASSWORD":
-			if ver.Distribution == elastic.Easysearch {
-				return w.Write([]byte(ingestPassword))
-			} else {
-				return w.Write([]byte(request.Cluster.Password))
-			}
+			return w.Write([]byte(agentUsername))
+		case "SETUP_AGENT_PASSWORD_KEY":
+			return w.Write([]byte(agentPasswordKey))
 		case "SETUP_SCHEME":
 			return w.Write([]byte(request.Cluster.Schema))
 		case "SETUP_ENDPOINTS":
@@ -1019,37 +1088,39 @@ func (module *Module) initializeTemplate(w http.ResponseWriter, r *http.Request,
 
 // initIngestUser initializes the ingest user with the required permissions for writing metrics and logs.
 func initIngestUser(client elastic.API, indexPrefix string, username, password string) error {
-	roleTpl := `{
-	  "cluster": [
-		"cluster_monitor",
-		"cluster_composite_ops"
-	  ],
-	 "description": "Provide the minimum permissions for INFINI AGENT to write metrics and logs",
-	  "indices": [{
-		"names": [
-		  "%slogs*", "%smetrics*"
-		],
-		"query": "",
-		"field_security": [],
-		"field_mask": [],
-		"privileges": [
-		  "create_index","index","manage_aliases","write"
-		]
-	  }]
-	}`
-	roleBody := fmt.Sprintf(roleTpl, indexPrefix, indexPrefix)
-	err := client.PutRole(username, []byte(roleBody))
+	roleBody := util.MustToJSONBytes(util.MapStr{
+		"cluster": []string{
+			"cluster_monitor",
+			"cluster_composite_ops",
+		},
+		"description": "Provide the minimum permissions for INFINI AGENT to write metrics and logs",
+		"indices": []util.MapStr{
+			{
+				"names": []string{
+					fmt.Sprintf("%slogs*", indexPrefix),
+					fmt.Sprintf("%smetrics*", indexPrefix),
+				},
+				"query":          "",
+				"field_security": []string{},
+				"field_mask":     []string{},
+				"privileges": []string{
+					"create_index",
+					"index",
+					"manage_aliases",
+					"write",
+				},
+			},
+		},
+	})
+	err := client.PutRole(username, roleBody)
 	if err != nil {
 		return fmt.Errorf("failed to create ingest role: %w", err)
 	}
-	userTpl := `{
-		"roles": [
-			"%s"
-		],
-		"password": "%s"}`
-
-	userBody := fmt.Sprintf(userTpl, username, password)
-	err = client.PutUser(username, []byte(userBody))
+	userBody := util.MustToJSONBytes(util.MapStr{
+		"roles":    []string{username},
+		"password": password,
+	})
+	err = client.PutUser(username, userBody)
 	if err != nil {
 		return fmt.Errorf("failed to create ingest user: %w", err)
 	}

--- a/web/src/pages/Guide/Initialization/components/Configuration/index.js
+++ b/web/src/pages/Guide/Initialization/components/Configuration/index.js
@@ -1,124 +1,162 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Alert, Button, Form, Icon, Input, Switch, Select } from 'antd';
 import request from '@/utils/request';
 import { formatMessage } from "umi/locale";
-import TrimSpaceInput from '@/components/TrimSpaceInput';
+import {
+    getClusterConnectErrorMessageFromError,
+    getClusterConnectErrorMessageFromResponse,
+} from '@/pages/System/Cluster/utils';
 
 const formItemLayout = {
-    labelCol: {
-        md: { span: 8 },
-    },
-    wrapperCol: {
-        md: { span: 10 },
-    },
+    labelCol: { md: { span: 8 } },
+    wrapperCol: { md: { span: 10 } },
+};
+
+const stripSchema = (host = '') => host.trim().replace(/^https?:\/\//i, '');
+const normalizeHosts = (hosts = []) => (hosts || []).map(stripSchema).filter(Boolean);
+
+const detectTLS = (hosts = []) => {
+    let result = null;
+    for (const h of hosts) {
+        if (/^https:\/\//i.test(h.trim())) result = true;
+        else if (/^http:\/\//i.test(h.trim())) result = false;
+    }
+    return result;
 };
 
 export default ({ onNext, form, formData, onFormDataChange }) => {
 
     const [testLoading, setTestLoading] = useState(false);
-    const [testStatus, setTestStatus] = useState();
-    const [testError, setTestError] = useState();
+    const [testStatus, setTestStatus]   = useState();
+    const [testError, setTestError]     = useState();
+    const [clusterDefaults, setClusterDefaults] = useState({});
 
     const checkVersion = (version, distribution) => {
         if (!version) return false;
-        if(distribution === "easysearch" || distribution === "opensearch"){
-            return true
-        }
-        const base = '5.3';
-        const baseSplit = base.split('.').map(x => parseInt(x))
-        const versionSplit = version.split('.').map(x => parseInt(x))
-        if(baseSplit[0] > versionSplit[0]){
-            return false
-        }else if(baseSplit[0] < versionSplit[0]){
-            return true
-        }
-        if(baseSplit[1] > versionSplit[1]){
-            return false
-        }else if(baseSplit[1] < versionSplit[1]){
-            return true
-        }
-        return true
-    }
+        if (distribution === 'easysearch' || distribution === 'opensearch') return true;
+        const [bMajor, bMinor] = '5.3'.split('.').map(Number);
+        const [vMajor, vMinor] = version.split('.').map(Number);
+        if (vMajor !== bMajor) return vMajor > bMajor;
+        return vMinor >= bMinor;
+    };
+
+    const getRecommendedPrimaryShards = (res) => {
+        const dataNodes  = Number(res?.number_of_data_nodes) || 0;
+        const totalNodes = Number(res?.number_of_nodes) || 0;
+        return Math.max(1, dataNodes || totalNodes || 1);
+    };
+
+    const resetTestStatus = () => {
+        if (testStatus) setTestStatus(undefined);
+        if (testError)  setTestError(undefined);
+        setClusterDefaults({});
+    };
+
+    const handleHostsChange = (values) => {
+        const tls     = detectTLS(values);
+        const cleaned = normalizeHosts(values);
+
+        if (tls !== null) form.setFieldsValue({ isTLS: tls });
+
+        const patch = { hosts: cleaned };
+        if (tls !== null) patch.isTLS = tls;
+        onFormDataChange(patch);
+
+        resetTestStatus();
+    };
 
     const onTest = async (callback) => {
         form.validateFields(async (err, values) => {
-            if (err) {
-              return false;
-            }
+            if (err) return;
+
             try {
                 setTestLoading(true);
-                setTestStatus();
-                setTestError();
+                setTestStatus(undefined);
+                setTestError(undefined);
+
                 const { hosts, isTLS, isAuth, username, password } = values;
+
                 const body = {
-                    hosts: (hosts || []).map(host=>host.trim()),
-                    schema: isTLS === true ? "https" : "http",
-                }
-                if (isAuth) {
-                    body.basic_auth =  {
-                        username,
-                        password,
-                    }
-                }
+                    hosts:  normalizeHosts(hosts),
+                    schema: isTLS ? 'https' : 'http',
+                };
+                if (isAuth) body.basic_auth = { username, password };
 
                 const res = await request('/elasticsearch/try_connect', {
-                    method: "POST",
-                    body: body,
-                }, undefined, false)
+                    method: 'POST',
+                    body,
+                }, undefined, false);
+
                 if (['green', 'yellow'].includes(res?.status)) {
                     if (checkVersion(res?.version, res?.distribution)) {
-                        setTestStatus('success')
-                        if (callback) callback()
+                        const nextDefaults = {
+                            distribution:         res?.distribution,
+                            version:              res?.version,
+                            number_of_nodes:      res?.number_of_nodes,
+                            number_of_data_nodes: res?.number_of_data_nodes,
+                            primary_shards:       getRecommendedPrimaryShards(res),
+                            auto_expand_replicas: formData.auto_expand_replicas || '0-1',
+                        };
+                        setTestStatus('success');
+                        setClusterDefaults(nextDefaults);
+                        if (callback) callback(nextDefaults);
                     } else {
-                        setTestStatus('error')
-                        setTestError(formatMessage({ id: 'guide.cluster.test.connection.error.version'}))
+                        setTestStatus('error');
+                        setTestError(formatMessage({ id: 'guide.cluster.test.connection.error.version' }));
                     }
                 } else {
-                    setTestStatus('error')
-                    setTestError(formatMessage({ id: 'guide.cluster.test.connection.failed'}))
+                    setTestStatus('error');
+                    setTestError(
+                        getClusterConnectErrorMessageFromResponse(res, 'guide.cluster.test.connection.failed')
+                    );
                 }
-                setTestLoading(false);
             } catch (error) {
-                console.log(error);
-                setTestStatus('error')
+                setTestStatus('error');
+                setTestError(
+                    await getClusterConnectErrorMessageFromError(error, 'guide.cluster.test.connection.failed')
+                );
+            } finally {
                 setTestLoading(false);
             }
         });
-    }
+    };
 
-    const resetTestStatus = () => {
-        !!testStatus && setTestStatus()
-        !!testError && setTestError()
-    }
-
-    const onSubmit = async (e) => {
+    const onSubmit = (e) => {
         e.preventDefault();
-        
         if (!testStatus || testStatus === 'error') {
-            onTest(onFormDataSave)
+            onTest(onFormDataSave);
             return;
         }
-
         onFormDataSave();
-    }
+    };
 
-    const onFormDataSave = () => {
+    const onFormDataSave = (defaults = clusterDefaults) => {
         const values = form.getFieldsValue();
-        const { hosts, isAuth, username, password } = values;
+        const { hosts, isTLS, isAuth, username, password } = values;
+
         onFormDataChange({
-            hosts: (hosts || []).map(host=>host.trim()),
-            isAuth, username, password
-        })
+            hosts:                normalizeHosts(hosts),
+            isTLS,
+            isAuth,
+            username,
+            password,
+            distribution:         defaults?.distribution,
+            version:              defaults?.version,
+            number_of_nodes:      defaults?.number_of_nodes,
+            number_of_data_nodes: defaults?.number_of_data_nodes,
+            primary_shards:       formData.primary_shards       || defaults?.primary_shards,
+            auto_expand_replicas: formData.auto_expand_replicas || defaults?.auto_expand_replicas,
+        });
         onNext();
-    }
+    };
+
     const validateHostsRule = (rule, value, callback) => {
-        let vals = value || [];
-        for(let i = 0; i < vals.length; i++) {
-            if (!/^[\w\.\-_~%]+(\:\d+)?$/.test(vals[i])) {
-                return callback(formatMessage({ id: 'guide.cluster.host.validate'}));
+        for (const raw of (value || [])) {
+            const host = stripSchema(raw);
+            if (!/^[\w.\-_~%]+(:\d+)?$/.test(host)) {
+                return callback(formatMessage({ id: 'guide.cluster.host.validate' }));
             }
         }
-        // validation passed
         callback();
     };
 
@@ -126,90 +164,95 @@ export default ({ onNext, form, formData, onFormDataChange }) => {
 
     return (
         <Form {...formItemLayout} onSubmit={onSubmit} colon={false}>
-            <Form.Item label={formatMessage({ id: 'guide.cluster.host'})}>
-                {getFieldDecorator("hosts", {
+            <Form.Item label={formatMessage({ id: 'guide.cluster.host' })}>
+                {getFieldDecorator('hosts', {
                     initialValue: formData.hosts,
+                    normalize: normalizeHosts,
                     rules: [
                         {
                             required: true,
-                            message: formatMessage({ id: 'guide.cluster.host.required'}),
+                            message: formatMessage({ id: 'guide.cluster.host.required' }),
                         },
-                        {
-                            validator: validateHostsRule,
-                        }
+                        { validator: validateHostsRule },
                     ],
-                })(<Select placeholder="127.0.0.1:9200" mode="tags" allowClear={true} onChange={resetTestStatus}/>)}
+                })(
+                    <Select
+                        placeholder="127.0.0.1:9200"
+                        mode="tags"
+                        allowClear
+                        onChange={handleHostsChange}
+                    />
+                )}
             </Form.Item>
+
             <Form.Item label="TLS">
-                {getFieldDecorator("isTLS", {
+                {getFieldDecorator('isTLS', {
                     initialValue: formData.isTLS,
-                    valuePropName: 'checked'
-                })(<Switch size="small" onChange={(checked) => {
-                    resetTestStatus();
-                    onFormDataChange({ isTLS: checked })
-                }}/>)}
+                    valuePropName: 'checked',
+                })(
+                    <Switch size="small" onChange={(checked) => {
+                        resetTestStatus();
+                        onFormDataChange({ isTLS: checked });
+                    }} />
+                )}
             </Form.Item>
-            <Form.Item label={formatMessage({ id: 'guide.cluster.auth'})}>
-                {getFieldDecorator("isAuth", { 
+
+            <Form.Item label={formatMessage({ id: 'guide.cluster.auth' })}>
+                {getFieldDecorator('isAuth', {
                     initialValue: formData.isAuth,
-                    valuePropName: 'checked'
-                })(<Switch size="small" onChange={(checked) => {
-                    resetTestStatus();
-                    onFormDataChange({ isAuth: checked })
-                }}/>)}
+                    valuePropName: 'checked',
+                })(
+                    <Switch size="small" onChange={(checked) => {
+                        resetTestStatus();
+                        onFormDataChange({ isAuth: checked });
+                    }} />
+                )}
             </Form.Item>
-            {
-                formData.isAuth && (
-                    <>
-                        <Form.Item label={formatMessage({ id: 'guide.username'})}>
-                            {getFieldDecorator("username", {
-                                initialValue: formData.username,
-                                rules: [
-                                    {
-                                        required: true,
-                                        message: formatMessage({ id: 'guide.username.required'}),
-                                    }
-                                ],
-                            })(<Input onChange={resetTestStatus}/>)}
-                        </Form.Item>
-                        <Form.Item label={formatMessage({ id: 'guide.password'})}>
-                            {getFieldDecorator("password", {
-                                rules: [{
-                                    required: true,
-                                    message: formatMessage({ id: 'guide.password.required'}),
-                                }],
-                            })(<Input.Password onChange={resetTestStatus}/>)}
-                        </Form.Item>
-                    </>
-                )
-            }
-            {
-                testError && (
-                    <Form.Item label=" ">
-                        <Alert message={testError} type="error" />
+
+            {formData.isAuth && (
+                <>
+                    <Form.Item label={formatMessage({ id: 'guide.username' })}>
+                        {getFieldDecorator('username', {
+                            initialValue: formData.username,
+                            rules: [{
+                                required: true,
+                                message: formatMessage({ id: 'guide.username.required' }),
+                            }],
+                        })(<Input onChange={resetTestStatus} />)}
                     </Form.Item>
-                )
-            }
+                    <Form.Item label={formatMessage({ id: 'guide.password' })}>
+                        {getFieldDecorator('password', {
+                            rules: [{
+                                required: true,
+                                message: formatMessage({ id: 'guide.password.required' }),
+                            }],
+                        })(<Input.Password onChange={resetTestStatus} />)}
+                    </Form.Item>
+                </>
+            )}
+
+            {testError && (
+                <Form.Item label=" ">
+                    <Alert message={testError} type="error" />
+                </Form.Item>
+            )}
+
             <Form.Item label=" ">
-                <div style={{ display: 'flex', justifyContent: 'space-between'}}>
-                    <Button style={{width: '48%'}} loading={testLoading} onClick={() => onTest()}>
-                        {
-                            testStatus === 'success' && (
-                                <Icon style={{ color: '#27b148'}} type="check-circle" theme="filled" />
-                            )
-                        }
-                        {
-                            testStatus === 'error' && (
-                                <Icon style={{ color: '#ff0000'}} type="close-circle" theme="filled" />
-                            )
-                        }
-                        {formatMessage({ id: 'guide.cluster.test.connection'})}
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <Button style={{ width: '48%' }} loading={testLoading} onClick={() => onTest()}>
+                        {testStatus === 'success' && (
+                            <Icon style={{ color: '#27b148' }} type="check-circle" theme="filled" />
+                        )}
+                        {testStatus === 'error' && (
+                            <Icon style={{ color: '#ff0000' }} type="close-circle" theme="filled" />
+                        )}
+                        {formatMessage({ id: 'guide.cluster.test.connection' })}
                     </Button>
-                    <Button style={{width: '48%'}} disabled={testLoading} type="primary" htmlType="submit">
-                        {formatMessage({ id: 'guide.step.next'})}
+                    <Button style={{ width: '48%' }} disabled={testLoading} type="primary" htmlType="submit">
+                        {formatMessage({ id: 'guide.step.next' })}
                     </Button>
                 </div>
             </Form.Item>
         </Form>
-    )
-}
+    );
+};

--- a/web/src/pages/Guide/Initialization/components/Initialization/index.less
+++ b/web/src/pages/Guide/Initialization/components/Initialization/index.less
@@ -48,6 +48,13 @@
         }
     }
 
+    .credentialSecretTip {
+        color: #ff0000;
+        line-height: 20px;
+        opacity: 0.7;
+        white-space: nowrap;
+    }
+
     .refresh {
         cursor: pointer;
     }

--- a/web/src/pages/Guide/Initialization/components/Settings/index.jsx
+++ b/web/src/pages/Guide/Initialization/components/Settings/index.jsx
@@ -341,14 +341,7 @@ export default ({ onPrev, onNext, form, formData, onFormDataChange }) => {
             )}
           </Form.Item>
           <Form.Item label=" ">
-            <div
-              style={{
-                color: "#ff0000",
-                lineHeight: "20px",
-                opacity: 0.7,
-                wordBreak: "break-all",
-              }}
-            >
+            <div className={styles.credentialSecretTip}>
               {formatMessage({ id: "guide.credential_secret.tips" })}
             </div>
           </Form.Item>
@@ -412,14 +405,7 @@ export default ({ onPrev, onNext, form, formData, onFormDataChange }) => {
          
         </Form.Item>
         <Form.Item label=" ">
-          <div
-            style={{
-              color: "#ff0000",
-              lineHeight: "20px",
-              opacity: 0.7,
-              wordBreak: "break-all",
-            }}
-          >
+          <div className={styles.credentialSecretTip}>
             {formatMessage({ id: "guide.credential_secret.tips" })}
           </div>
         </Form.Item>


### PR DESCRIPTION
## Summary
- hydrate system cluster basic auth before deferred setup initialization continues
- persist setup-created records with refresh semantics and invoke callbacks only after setup state is updated
- normalize setup hosts input and reuse shared credential tip styling in the initialization UI