### PR TITLE
fix: request enough status buckets for index overview health

### DIFF
--- a/modules/elastic/api/v1/index_overview.go
+++ b/modules/elastic/api/v1/index_overview.go
@@ -757,6 +757,7 @@ func (h *APIHandler) GetIndexStatusOfRecentDay(clusterID, indexName string) (map
 					"term_health": util.MapStr{
 						"terms": util.MapStr{
 							"field": "payload.elasticsearch.index_health.status",
+							"size":  10,
 						},
 					},
 				},


### PR DESCRIPTION
## Summary
- set an explicit terms aggregation size when collecting recent index health statuses
- avoid truncated status buckets in the index overview response