### PR TITLE
fix(security): enforce single active JWT per user

### DIFF
--- a/core/security/access_token.go
+++ b/core/security/access_token.go
@@ -56,7 +56,11 @@ func GenerateAccessToken(user *User) (map[string]interface{}, error) {
 		return nil, errors.Errorf("failed to generate access_token for user: %v", user.Username)
 	}
 
-	token := Token{ExpireIn: time.Now().Unix() + 86400}
+	token := Token{
+		JwtStr:   tokenString,
+		Value:    tokenString,
+		ExpireIn: time.Now().Unix() + 86400,
+	}
 	SetUserToken(user.ID, token)
 
 	data = util.MapStr{

--- a/core/security/validate.go
+++ b/core/security/validate.go
@@ -351,6 +351,14 @@ func ValidateLogin(authorizationHeader string) (clams *UserClaims, err error) {
 		DeleteUserToken(clams.UserId)
 		return
 	}
+	activeToken := tokenVal.Value
+	if activeToken == "" {
+		activeToken = tokenVal.JwtStr
+	}
+	if activeToken != "" && activeToken != tokenString {
+		err = errors.New("token is invalid")
+		return
+	}
 	if ok && token.Valid {
 		return clams, nil
 	}

--- a/core/security/validate_test.go
+++ b/core/security/validate_test.go
@@ -1,0 +1,117 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package security
+
+import (
+	"github.com/golang-jwt/jwt"
+	"testing"
+	"time"
+)
+
+func issueTestToken(t *testing.T, userID string) string {
+	t.Helper()
+
+	expireAt := time.Now().Add(time.Hour)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, UserClaims{
+		ShortUser: &ShortUser{
+			Provider: "native",
+			Username: "tester",
+			UserId:   userID,
+		},
+		RegisteredClaims: &jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expireAt),
+		},
+	})
+
+	tokenString, err := token.SignedString([]byte(Secret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	userTokenLocker.Lock()
+	tokenMap[userID] = Token{
+		Value:    tokenString,
+		ExpireIn: expireAt.Unix(),
+	}
+	userTokenLocker.Unlock()
+
+	t.Cleanup(func() {
+		userTokenLocker.Lock()
+		delete(tokenMap, userID)
+		userTokenLocker.Unlock()
+	})
+
+	return tokenString
+}
+
+func TestValidateLoginRejectsReplacedActiveToken(t *testing.T) {
+	userID := "user-revoked"
+	authorizationHeader := "Bearer " + issueTestToken(t, userID)
+	if _, err := ValidateLogin(authorizationHeader); err != nil {
+		t.Fatalf("expected token to validate before revoke, got %v", err)
+	}
+
+	userTokenLocker.Lock()
+	tokenMap[userID] = Token{
+		Value:    "replaced-token",
+		ExpireIn: time.Now().Add(time.Hour).Unix(),
+	}
+	userTokenLocker.Unlock()
+
+	if _, err := ValidateLogin(authorizationHeader); err == nil {
+		t.Fatal("expected replaced token to be rejected")
+	}
+}
+
+func TestValidateLoginRejectsStaleTokenValue(t *testing.T) {
+	userID := "user-stale"
+	authorizationHeader := "Bearer " + issueTestToken(t, userID)
+
+	userTokenLocker.Lock()
+	tokenMap[userID] = Token{
+		Value:    "replacement-token",
+		ExpireIn: time.Now().Add(time.Hour).Unix(),
+	}
+	userTokenLocker.Unlock()
+
+	if _, err := ValidateLogin(authorizationHeader); err == nil {
+		t.Fatal("expected stale token to be rejected")
+	}
+}
+
+func TestValidateLoginSupportsLegacyJwtField(t *testing.T) {
+	userID := "user-legacy"
+	tokenString := issueTestToken(t, userID)
+
+	userTokenLocker.Lock()
+	tokenMap[userID] = Token{
+		JwtStr:   tokenString,
+		ExpireIn: time.Now().Add(time.Hour).Unix(),
+	}
+	userTokenLocker.Unlock()
+
+	if _, err := ValidateLogin("Bearer " + tokenString); err != nil {
+		t.Fatalf("expected legacy jwt field to remain valid, got %v", err)
+	}
+}

--- a/modules/security/api/account.go
+++ b/modules/security/api/account.go
@@ -49,11 +49,19 @@ const NativeProvider = "native"
 func (h APIHandler) Logout(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	reqUser, err := rbac.FromUserContext(r.Context())
 	if err != nil {
-		h.ErrorInternalServer(w, err.Error())
-		return
+		if api.IsAuthEnable() {
+			claims, validateErr := rbac.ValidateLogin(r.Header.Get("Authorization"))
+			if validateErr != nil {
+				h.WriteError(w, validateErr.Error(), http.StatusUnauthorized)
+				return
+			}
+			reqUser = claims.ShortUser
+		}
 	}
 
-	rbac.DeleteUserToken(reqUser.UserId)
+	if reqUser != nil && reqUser.UserId != "" {
+		rbac.DeleteUserToken(reqUser.UserId)
+	}
 	h.WriteOKJSON(w, util.MapStr{
 		"status": "ok",
 	})


### PR DESCRIPTION
## Summary
- invalidate older JWT sessions when a new session is issued
- tighten token validation state in account flows
- keep this auth hardening isolated from managed-agent changes
