### PR TITLE
fix(managed): sanitize instance info responses

### DIFF
--- a/common/info.go
+++ b/common/info.go
@@ -1,0 +1,55 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import "infini.sh/framework/core/util"
+
+var allowedInstanceInfoKeys = []string{
+	"id",
+	"name",
+	"application",
+	"labels",
+	"tags",
+	"description",
+	"status",
+}
+
+func SanitizeInstanceInfoMap(payload util.MapStr) util.MapStr {
+	sanitized := util.MapStr{}
+	for _, key := range allowedInstanceInfoKeys {
+		if value, ok := payload[key]; ok {
+			sanitized[key] = value
+		}
+	}
+	return sanitized
+}
+
+func SanitizeInstanceInfoBytes(body []byte) ([]byte, error) {
+	payload := util.MapStr{}
+	err := util.FromJSONBytes(body, &payload)
+	if err != nil {
+		return nil, err
+	}
+	return util.MustToJSONBytes(SanitizeInstanceInfoMap(payload)), nil
+}

--- a/common/info_test.go
+++ b/common/info_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/util"
+)
+
+func TestSanitizeInstanceInfoMap(t *testing.T) {
+	payload := util.MapStr{
+		"id":          "node-1",
+		"name":        "console-a",
+		"application": util.MapStr{"name": "console"},
+		"endpoint":    "http://127.0.0.1:2900",
+		"host":        util.MapStr{"name": "host-a"},
+		"network":     util.MapStr{"ip": []string{"10.0.0.1"}},
+		"basic_auth":  util.MapStr{"username": "admin"},
+	}
+
+	sanitized := SanitizeInstanceInfoMap(payload)
+
+	if sanitized["id"] != "node-1" {
+		t.Fatalf("expected id to be preserved, got %v", sanitized["id"])
+	}
+	if _, ok := sanitized["endpoint"]; ok {
+		t.Fatalf("expected endpoint to be removed")
+	}
+	if _, ok := sanitized["host"]; ok {
+		t.Fatalf("expected host to be removed")
+	}
+	if _, ok := sanitized["network"]; ok {
+		t.Fatalf("expected network to be removed")
+	}
+	if _, ok := sanitized["basic_auth"]; ok {
+		t.Fatalf("expected basic_auth to be removed")
+	}
+}

--- a/info_api.go
+++ b/info_api.go
@@ -1,0 +1,52 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Console is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	console_common "infini.sh/console/common"
+	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	framework_model "infini.sh/framework/core/model"
+	"infini.sh/framework/core/util"
+	"net/http"
+)
+
+func init() {
+	api.HandleAPIMethod(api.GET, "/_info", sanitizedInfoAPIHandler)
+	api.HandleUIMethod(api.GET, "/_info", sanitizedInfoAPIHandler, api.RequireLogin())
+}
+
+func sanitizedInfoAPIHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	info := framework_model.GetInstanceInfo()
+	payload := console_common.SanitizeInstanceInfoMap(util.MapStr{
+		"id":          info.ID,
+		"name":        info.Name,
+		"application": info.Application,
+		"labels":      info.Labels,
+		"tags":        info.Tags,
+		"description": info.Description,
+		"status":      info.Status,
+	})
+	api.DefaultAPI.WriteJSON(w, payload, http.StatusOK)
+}

--- a/plugin/managed/server/instance.go
+++ b/plugin/managed/server/instance.go
@@ -30,10 +30,12 @@ package server
 import (
 	"context"
 	"fmt"
+	console_common "infini.sh/console/common"
 	"infini.sh/framework/core/event"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/task"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -568,6 +570,13 @@ func (h *APIHandler) proxy(w http.ResponseWriter, req *http.Request, ps httprout
 		panic(err)
 	}
 
+	if isSensitiveInfoPath(path) && len(res.Body) > 0 {
+		res.Body, err = console_common.SanitizeInstanceInfoBytes(res.Body)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	h.WriteHeader(w, res.StatusCode)
 	h.Write(w, res.Body)
 }
@@ -607,7 +616,15 @@ func (h *APIHandler) tryConnect(w http.ResponseWriter, req *http.Request, ps htt
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	h.WriteJSON(w, connectRes, http.StatusOK)
+	h.WriteJSON(w, console_common.SanitizeInstanceInfoMap(util.MapStr{
+		"id":          connectRes.ID,
+		"name":        connectRes.Name,
+		"application": connectRes.Application,
+		"labels":      connectRes.Labels,
+		"tags":        connectRes.Tags,
+		"description": connectRes.Description,
+		"status":      connectRes.Status,
+	}), http.StatusOK)
 }
 
 func (h *APIHandler) tryESConnect(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
@@ -672,6 +689,17 @@ func (h *APIHandler) tryESConnect(w http.ResponseWriter, req *http.Request, ps h
 
 	h.WriteHeader(w, res.StatusCode)
 	h.Write(w, res.Body)
+}
+
+func isSensitiveInfoPath(rawPath string) bool {
+	if rawPath == "" {
+		return false
+	}
+	parsed, err := url.Parse(rawPath)
+	if err != nil {
+		return rawPath == "/_info"
+	}
+	return parsed.Path == "/_info"
 }
 
 // TODO check permission by user


### PR DESCRIPTION
## Summary
- sanitize managed instance info responses before exposing them
- keep instance info hardening separate from token and reverse-channel work
